### PR TITLE
OMRON NJ/NX Series Ethernet/IP initial support.

### DIFF
--- a/src/protocols/ab/ab_common.c
+++ b/src/protocols/ab/ab_common.c
@@ -384,8 +384,10 @@ plc_tag_p ab_tag_create(attr attribs)
     case AB_PLC_OMRON_NJNX:
         pdebug(DEBUG_DETAIL, "Setting up OMRON NJ/NX Series tag.");
 
-        if(path || str_length(path)) {
-            pdebug(DEBUG_WARN, "A path is not supported for this PLC type.");
+        if(str_length(path) == 0) {
+            pdebug(DEBUG_WARN,"A path is required for this PLC type.");
+            tag->status = PLCTAG_ERR_BAD_PARAM;
+            return (plc_tag_p)tag;
         }
 
         tag->use_connected_msg = 1;

--- a/src/protocols/ab/cip.c
+++ b/src/protocols/ab/cip.c
@@ -538,6 +538,7 @@ int match_ip_addr_segment(const char *path, size_t *path_index, uint8_t *conn_pa
 
     /* point into the encoded path for the symbolic segment length. */
     addr_seg_len = &conn_path[c_index];
+    *addr_seg_len = 0;
     c_index++;
 
     /* get the first IP address digit. */

--- a/src/protocols/ab/defs.h
+++ b/src/protocols/ab/defs.h
@@ -207,7 +207,7 @@
 //#define AB_PLC_MLGX800     (4)
 //#define AB_PLC_LGX_PCCC    (5)
 
-typedef enum { AB_PLC_NONE = 0, AB_PLC_PLC5 = 1, AB_PLC_SLC, AB_PLC_MLGX, AB_PLC_LGX, AB_PLC_LGX_PCCC, AB_PLC_MLGX800 } plc_type_t;
+typedef enum { AB_PLC_NONE = 0, AB_PLC_PLC5 = 1, AB_PLC_SLC, AB_PLC_MLGX, AB_PLC_LGX, AB_PLC_LGX_PCCC, AB_PLC_MLGX800, AB_PLC_OMRON_NJNX } plc_type_t;
 
 
 /*********************************************************************

--- a/src/protocols/ab/eip_cip.c
+++ b/src/protocols/ab/eip_cip.c
@@ -128,11 +128,11 @@ START_PACK typedef struct {
 
 
 
-static int build_read_request_connected(ab_tag_p tag, int byte_offset);
+static int build_read_request_connected(ab_tag_p tag, int frag, int byte_offset);
 static int build_tag_list_request_connected(ab_tag_p tag);
-static int build_read_request_unconnected(ab_tag_p tag, int byte_offset);
-static int build_write_request_connected(ab_tag_p tag, int byte_offset);
-static int build_write_request_unconnected(ab_tag_p tag, int byte_offset);
+static int build_read_request_unconnected(ab_tag_p tag, int frag, int byte_offset);
+static int build_write_request_connected(ab_tag_p tag, int frag, int byte_offset);
+static int build_write_request_unconnected(ab_tag_p tag, int frag, int byte_offset);
 static int build_write_bit_request_connected(ab_tag_p tag);
 static int build_write_bit_request_unconnected(ab_tag_p tag);
 static int check_read_status_connected(ab_tag_p tag);
@@ -142,9 +142,13 @@ static int check_write_status_connected(ab_tag_p tag);
 static int check_write_status_unconnected(ab_tag_p tag);
 static int calculate_write_data_per_packet(ab_tag_p tag);
 
+static int tag_read_common_start(ab_tag_p tag, int frag);
 static int tag_read_start(ab_tag_p tag);
+static int tag_read_frag_start(ab_tag_p tag);
 static int tag_tickler(ab_tag_p tag);
+static int tag_write_common_start(ab_tag_p tag, int frag);
 static int tag_write_start(ab_tag_p tag);
+static int tag_write_frag_start(ab_tag_p tag);
 
 /* define the exported vtable for this tag type. */
 struct tag_vtable_t eip_cip_vtable = {
@@ -153,6 +157,51 @@ struct tag_vtable_t eip_cip_vtable = {
     (tag_vtable_func)ab_tag_status, /* shared */
     (tag_vtable_func)tag_tickler,
     (tag_vtable_func)tag_write_start,
+
+    /* data accessors */
+    ab_get_int_attrib,
+    ab_set_int_attrib,
+
+    ab_get_bit,
+    ab_set_bit,
+
+    ab_get_uint64,
+    ab_set_uint64,
+
+    ab_get_int64,
+    ab_set_int64,
+
+    ab_get_uint32,
+    ab_set_uint32,
+
+    ab_get_int32,
+    ab_set_int32,
+
+    ab_get_uint16,
+    ab_set_uint16,
+
+    ab_get_int16,
+    ab_set_int16,
+
+    ab_get_uint8,
+    ab_set_uint8,
+
+    ab_get_int8,
+    ab_set_int8,
+
+    ab_get_float64,
+    ab_set_float64,
+
+    ab_get_float32,
+    ab_set_float32
+};
+
+struct tag_vtable_t eip_cip_frag_vtable = {
+    (tag_vtable_func)ab_tag_abort, /* shared */
+    (tag_vtable_func)tag_read_frag_start,
+    (tag_vtable_func)ab_tag_status, /* shared */
+    (tag_vtable_func)tag_tickler,
+    (tag_vtable_func)tag_write_frag_start,
 
     /* data accessors */
     ab_get_int_attrib,
@@ -258,7 +307,7 @@ int tag_tickler(ab_tag_p tag)
 
 
 /*
- * tag_read_start
+ * tag_read_common_start
  *
  * This function must be called only from within one thread, or while
  * the tag's mutex is locked.
@@ -266,7 +315,7 @@ int tag_tickler(ab_tag_p tag)
  * The function starts the process of getting tag data from the PLC.
  */
 
-int tag_read_start(ab_tag_p tag)
+int tag_read_common_start(ab_tag_p tag, int frag)
 {
     int rc = PLCTAG_STATUS_OK;
 
@@ -285,10 +334,10 @@ int tag_read_start(ab_tag_p tag)
         if(tag->tag_list) {
             rc = build_tag_list_request_connected(tag);
         } else {
-            rc = build_read_request_connected(tag, tag->offset);
+            rc = build_read_request_connected(tag, frag, tag->offset);
         }
     } else {
-        rc = build_read_request_unconnected(tag, tag->offset);
+        rc = build_read_request_unconnected(tag, frag, tag->offset);
     }
 
     if (rc != PLCTAG_STATUS_OK) {
@@ -306,11 +355,20 @@ int tag_read_start(ab_tag_p tag)
     return PLCTAG_STATUS_PENDING;
 }
 
+int tag_read_start(ab_tag_p tag)
+{
+    return tag_read_common_start(tag, 0);
+}
+
+int tag_read_frag_start(ab_tag_p tag)
+{
+    return tag_read_common_start(tag, 1);
+}
 
 
 
 /*
- * tag_write_start
+ * tag_write_common_start
  *
  * This must be called from one thread alone, or while the tag mutex is
  * locked.
@@ -318,7 +376,7 @@ int tag_read_start(ab_tag_p tag)
  * The routine starts the process of writing to a tag.
  */
 
-int tag_write_start(ab_tag_p tag)
+int tag_write_common_start(ab_tag_p tag, int frag)
 {
     int rc = PLCTAG_STATUS_OK;
 
@@ -363,9 +421,9 @@ int tag_write_start(ab_tag_p tag)
     }
 
     if(tag->use_connected_msg) {
-        rc = build_write_request_connected(tag, tag->offset);
+        rc = build_write_request_connected(tag, frag, tag->offset);
     } else {
-        rc = build_write_request_unconnected(tag, tag->offset);
+        rc = build_write_request_unconnected(tag, frag, tag->offset);
     }
 
     if (rc != PLCTAG_STATUS_OK) {
@@ -382,8 +440,17 @@ int tag_write_start(ab_tag_p tag)
     return PLCTAG_STATUS_PENDING;
 }
 
+static int tag_write_start(ab_tag_p tag)
+{
+    return tag_write_common_start(tag, 0);
+}
 
-int build_read_request_connected(ab_tag_p tag, int byte_offset)
+static int tag_write_frag_start(ab_tag_p tag)
+{
+    return tag_write_common_start(tag, 1);
+}
+
+int build_read_request_connected(ab_tag_p tag, int frag, int byte_offset)
 {
     eip_cip_co_req* cip = NULL;
     uint8_t* data = NULL;
@@ -417,7 +484,7 @@ int build_read_request_connected(ab_tag_p tag, int byte_offset)
     //embed_start = data;
 
     /* set up the CIP Read request */
-    *data = AB_EIP_CMD_CIP_READ_FRAG;
+    *data = frag ? AB_EIP_CMD_CIP_READ_FRAG : AB_EIP_CMD_CIP_READ;
     data++;
 
     /* copy the tag name into the request */
@@ -428,9 +495,11 @@ int build_read_request_connected(ab_tag_p tag, int byte_offset)
     *((uint16_le*)data) = h2le16((uint16_t)(tag->elem_count));
     data += sizeof(uint16_le);
 
-    /* add the byte offset for this request */
-    *((uint32_le*)data) = h2le32((uint32_t)byte_offset);
-    data += sizeof(uint32_le);
+    if (frag) {
+        /* add the byte offset for this request */
+        *((uint32_le*)data) = h2le32((uint32_t)byte_offset);
+        data += sizeof(uint32_le);
+    }
 
     /* now we go back and fill in the fields of the static part */
 
@@ -609,7 +678,7 @@ int build_tag_list_request_connected(ab_tag_p tag)
 
 
 
-int build_read_request_unconnected(ab_tag_p tag, int byte_offset)
+int build_read_request_unconnected(ab_tag_p tag, int frag, int byte_offset)
 {
     eip_cip_uc_req* cip;
     uint8_t* data;
@@ -645,7 +714,7 @@ int build_read_request_unconnected(ab_tag_p tag, int byte_offset)
     embed_start = data;
 
     /* set up the CIP Read request */
-    *data = AB_EIP_CMD_CIP_READ_FRAG;
+    *data = frag ? AB_EIP_CMD_CIP_READ_FRAG : AB_EIP_CMD_CIP_READ;
     data++;
 
     /* copy the tag name into the request */
@@ -1271,7 +1340,7 @@ int build_write_bit_request_unconnected(ab_tag_p tag)
 
 
 
-int build_write_request_connected(ab_tag_p tag, int byte_offset)
+int build_write_request_connected(ab_tag_p tag, int frag, int byte_offset)
 {
     int rc = PLCTAG_STATUS_OK;
     eip_cip_co_req* cip = NULL;
@@ -1299,7 +1368,7 @@ int build_write_request_connected(ab_tag_p tag, int byte_offset)
         return rc;
     }
 
-    if(tag->write_data_per_packet < tag->size) {
+    if(!frag && tag->write_data_per_packet < tag->size) {
         multiple_requests = 1;
     }
 
@@ -1411,7 +1480,7 @@ int build_write_request_connected(ab_tag_p tag, int byte_offset)
 
 
 
-int build_write_request_unconnected(ab_tag_p tag, int byte_offset)
+int build_write_request_unconnected(ab_tag_p tag, int frag, int byte_offset)
 {
     int rc = PLCTAG_STATUS_OK;
     eip_cip_uc_req* cip = NULL;
@@ -1441,7 +1510,7 @@ int build_write_request_unconnected(ab_tag_p tag, int byte_offset)
         return rc;
     }
 
-    if(tag->write_data_per_packet < tag->size) {
+    if(!frag && tag->write_data_per_packet < tag->size) {
         multiple_requests = 1;
     }
 

--- a/src/protocols/ab/eip_cip.h
+++ b/src/protocols/ab/eip_cip.h
@@ -42,6 +42,7 @@
 //extern int eip_cip_tag_tickler(ab_tag_p tag);
 
 extern struct tag_vtable_t eip_cip_vtable;
+extern struct tag_vtable_t eip_cip_frag_vtable;
 
 /* tag listing helpers */
 extern int setup_tag_listing(ab_tag_p tag, const char *name);

--- a/src/protocols/ab/session.c
+++ b/src/protocols/ab/session.c
@@ -511,6 +511,10 @@ ab_session_p session_create_unsafe(const char *host, int gw_port, const char *pa
         session->max_payload_size = MAX_CIP_MSG_SIZE;
         break;
 
+    case AB_PLC_OMRON_NJNX:
+        session->max_payload_size = MAX_CIP_MSG_SIZE;
+        break;
+
     default:
         pdebug(DEBUG_WARN, "Unknown protocol/cpu type!");
         rc_dec(session);


### PR DESCRIPTION
Proposed changes to add support for OMRON NJ/NX PLCs.

Added a new cpu (AB_PLC_OMRON_NJNX) under the ab_eip protocol.

Uses the existing code paths for MLGX800, I've added a new tag_vtable_t to handle cases where cpu doesn't support partial data and extra parameters to the build_[read|write]_request functions.

I also had to set to zero the ip address length in match_ip_addr_segment to make in work in Windows under MSVC.