### PR TITLE
Fix large tag breakage due to Omron merge.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,8 +12,8 @@ jobs:
     runs-on: ubuntu-latest
 
     env:
-      VERSION: "2.1.12"
-      ARTIFACT: "libplctag_2.1.12_ubuntu_x64"
+      VERSION: "2.1.13"
+      ARTIFACT: "libplctag_2.1.13_ubuntu_x64"
       BUILD: "${{ github.workspace }}/build"
       DIST: "${{ github.workspace }}/build/bin_dist"
 
@@ -101,8 +101,8 @@ jobs:
     runs-on: ubuntu-latest
 
     env:
-      VERSION: "2.1.12"
-      ARTIFACT: "libplctag_2.1.12_ubuntu_x86"
+      VERSION: "2.1.13"
+      ARTIFACT: "libplctag_2.1.13_ubuntu_x86"
       BUILD: "${{ github.workspace }}/build"
       DIST: "${{ github.workspace }}/build/bin_dist"
 
@@ -190,8 +190,8 @@ jobs:
     runs-on: macos-latest
 
     env:
-      VERSION: "2.1.12"
-      ARTIFACT: "libplctag_2.1.12_macos_x64"
+      VERSION: "2.1.13"
+      ARTIFACT: "libplctag_2.1.13_macos_x64"
       BUILD: "${{ github.workspace }}/build"
       DIST: "${{ github.workspace }}/build/bin_dist"
 
@@ -221,8 +221,8 @@ jobs:
     runs-on: windows-latest
 
     env:
-      VERSION: "2.1.12"
-      ARTIFACT: "libplctag_2.1.12_windows_x64"
+      VERSION: "2.1.13"
+      ARTIFACT: "libplctag_2.1.13_windows_x64"
       BUILD: "${{ github.workspace }}/build"
       DIST: "${{ github.workspace }}/build/bin_dist"
 
@@ -252,8 +252,8 @@ jobs:
     runs-on: windows-latest
 
     env:
-      VERSION: "2.1.12"
-      ARTIFACT: "libplctag_2.1.12_windows_x86"
+      VERSION: "2.1.13"
+      ARTIFACT: "libplctag_2.1.13_windows_x86"
       BUILD: "${{ github.workspace }}/build"
       DIST: "${{ github.workspace }}/build/bin_dist"
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,7 +33,7 @@
 # the project is version 2.1
 set (libplctag_VERSION_MAJOR 2)
 set (libplctag_VERSION_MINOR 1)
-set (libplctag_VERSION_PATCH 12)
+set (libplctag_VERSION_PATCH 13)
 set (VERSION "${libplctag_VERSION_MAJOR}.${libplctag_VERSION_MINOR}.${libplctag_VERSION_PATCH}")
 
 set (LIB_NAME_SUFFIX "${libplctag_VERSION_MAJOR}.${libplctag_VERSION_MINOR}.${libplctag_VERSION_PATCH}")

--- a/src/protocols/ab/ab_common.c
+++ b/src/protocols/ab/ab_common.c
@@ -333,7 +333,7 @@ plc_tag_p ab_tag_create(attr attribs)
         /* default to requiring a connection. */
         tag->use_connected_msg = attr_get_int(attribs,"use_connected_msg", 1);
         tag->allow_packing = attr_get_int(attribs, "allow_packing", 1);
-        tag->vtable = &eip_cip_frag_vtable;
+        tag->vtable = &eip_cip_vtable;
 
         break;
 
@@ -346,7 +346,7 @@ plc_tag_p ab_tag_create(attr attribs)
 
         tag->use_connected_msg = 1;
         tag->allow_packing = 0;
-        tag->vtable = &eip_cip_frag_vtable;
+        tag->vtable = &eip_cip_vtable;
         break;
 
     case AB_PLC_OMRON_NJNX:

--- a/src/protocols/ab/eip_cip.h
+++ b/src/protocols/ab/eip_cip.h
@@ -36,13 +36,7 @@
 
 #include <ab/ab_common.h>
 
-//extern int eip_cip_tag_status(ab_tag_p tag);
-//extern int eip_cip_tag_read_start(ab_tag_p tag);
-//extern int eip_cip_tag_write_start(ab_tag_p tag);
-//extern int eip_cip_tag_tickler(ab_tag_p tag);
-
 extern struct tag_vtable_t eip_cip_vtable;
-extern struct tag_vtable_t eip_cip_frag_vtable;
 
 /* tag listing helpers */
 extern int setup_tag_listing(ab_tag_p tag, const char *name);


### PR DESCRIPTION
The Omron merge broke handling of large tags.   This attempts to do the same changes as the original Omron merge, but in a different way that pushed the Omron-specific handling down deeper.   