### PR TITLE
Support multiple ForwardOpen attempts.   Add FO test and large tag tests to CI.  Add CI tests to macOS.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,8 +12,8 @@ jobs:
     runs-on: ubuntu-latest
 
     env:
-      VERSION: "2.1.13"
-      ARTIFACT: "libplctag_2.1.13_ubuntu_x64"
+      VERSION: "2.1.14"
+      ARTIFACT: "libplctag_2.1.14_ubuntu_x64"
       BUILD: "${{ github.workspace }}/build"
       DIST: "${{ github.workspace }}/build/bin_dist"
 
@@ -90,6 +90,28 @@ jobs:
         echo "shut down server."
         killall ab_server -INT &> /dev/null
 
+    - name: Test Duplicate Connection ID 
+      run: |
+        cd ${{ env.DIST }}
+        echo "start up simulator..."
+        ${{ env.DIST }}/ab_server --plc=ControlLogix --path=1,0 --tag=TestDINTArray:DINT[10] --reject-fo=5 &
+        sleep 2
+        echo "test simple get/set tag."
+        ${{ env.DIST }}/tag_rw -t sint32 -p 'protocol=ab-eip&gateway=127.0.0.1&path=1,0&plc=ControlLogix&name=TestDINTArray'
+        echo "shut down server."
+        killall ab_server -INT &> /dev/null
+
+    - name: Test Large Tags 
+      run: |
+        cd ${{ env.DIST }}
+        echo "start up simulator..."
+        ${{ env.DIST }}/ab_server --plc=ControlLogix --path=1,0 --tag=TestBigArray:DINT[2000] &
+        sleep 2
+        echo "test simple get/set tag."
+        ${{ env.DIST }}/tag_rw -t sint32 -p 'protocol=ab-eip&gateway=127.0.0.1&path=1,0&plc=ControlLogix&elem_count=2000&name=TestDINTArray'
+        echo "shut down server."
+        killall ab_server -INT &> /dev/null
+
     - name: Upload ZIP artifact
       uses: actions/upload-artifact@v1
       with:
@@ -101,8 +123,8 @@ jobs:
     runs-on: ubuntu-latest
 
     env:
-      VERSION: "2.1.13"
-      ARTIFACT: "libplctag_2.1.13_ubuntu_x86"
+      VERSION: "2.1.14"
+      ARTIFACT: "libplctag_2.1.14_ubuntu_x86"
       BUILD: "${{ github.workspace }}/build"
       DIST: "${{ github.workspace }}/build/bin_dist"
 
@@ -122,7 +144,7 @@ jobs:
     - name: Build
       run: cd ${{ env.BUILD }}; cmake --build .
 
-    - name: Test ControlLogix
+    - name: Test Basic Functions
       run: |
         cd ${{ env.DIST }}
         echo "start up simulator..."
@@ -179,6 +201,29 @@ jobs:
         echo "shut down server."
         killall ab_server -INT &> /dev/null
 
+
+    - name: Test Duplicate Connection ID 
+      run: |
+        cd ${{ env.DIST }}
+        echo "start up simulator..."
+        ${{ env.DIST }}/ab_server --plc=ControlLogix --path=1,0 --tag=TestDINTArray:DINT[10] --reject-fo=5 &
+        sleep 2
+        echo "test simple get/set tag."
+        ${{ env.DIST }}/tag_rw -t sint32 -p 'protocol=ab-eip&gateway=127.0.0.1&path=1,0&plc=ControlLogix&name=TestDINTArray'
+        echo "shut down server."
+        killall ab_server -INT &> /dev/null
+
+    - name: Test Large Tags 
+      run: |
+        cd ${{ env.DIST }}
+        echo "start up simulator..."
+        ${{ env.DIST }}/ab_server --plc=ControlLogix --path=1,0 --tag=TestBigArray:DINT[2000] &
+        sleep 2
+        echo "test simple get/set tag."
+        ${{ env.DIST }}/tag_rw -t sint32 -p 'protocol=ab-eip&gateway=127.0.0.1&path=1,0&plc=ControlLogix&elem_count=2000&name=TestDINTArray'
+        echo "shut down server."
+        killall ab_server -INT &> /dev/null
+
     - name: Upload ZIP artifact
       uses: actions/upload-artifact@v1
       with:
@@ -190,8 +235,8 @@ jobs:
     runs-on: macos-latest
 
     env:
-      VERSION: "2.1.13"
-      ARTIFACT: "libplctag_2.1.13_macos_x64"
+      VERSION: "2.1.14"
+      ARTIFACT: "libplctag_2.1.14_macos_x64"
       BUILD: "${{ github.workspace }}/build"
       DIST: "${{ github.workspace }}/build/bin_dist"
 
@@ -207,8 +252,85 @@ jobs:
     - name: Build
       run: cd ${{ env.BUILD }}; cmake --build .
 
-    - name: Test
-      run: echo "Tests suppressed on macOS."
+    - name: Test Basic Functions
+      run: |
+        cd ${{ env.DIST }}
+        echo "start up simulator..."
+        ${{ env.DIST }}/ab_server --plc=ControlLogix --path=1,0 --tag=TestBigArray:DINT[2000] &
+        sleep 2
+        echo "test simple get/set tag."
+        ${{ env.DIST }}/simple
+        echo "test callback use."
+        ${{ env.DIST }}/test_callback
+        echo "shut down server."
+        killall ab_server -INT &> /dev/null
+
+    - name: Test Micro800
+      run: |
+        cd ${{ env.DIST }}
+        echo "start up simulator..."
+        ${{ env.DIST }}/ab_server --plc=Micro800 --tag=TestDINTArray:DINT[10] &
+        sleep 2
+        echo "test simple get/set tag."
+        ${{ env.DIST }}/tag_rw -t sint32 -p 'protocol=ab_eip&gateway=127.0.0.1&cpu=micro800&elem_size=4&elem_count=1&name=TestDINTArray[0]'
+        echo "shut down server."
+        killall ab_server -INT &> /dev/null
+
+    - name: Test Omron NJ/NX
+      run: |
+        cd ${{ env.DIST }}
+        echo "start up simulator..."
+        ${{ env.DIST }}/ab_server --plc=Omron --tag=TestDINTArray:DINT[10] &
+        sleep 2
+        echo "test simple get/set tag."
+        ${{ env.DIST }}/tag_rw -t sint32 -p 'protocol=ab-eip&gateway=127.0.0.1&path=18,127.0.0.1&plc=omron-njnx&name=TestDINTArray'
+        echo "shut down server."
+        killall ab_server -INT &> /dev/null
+
+    - name: Test PLC/5
+      run: |
+        cd ${{ env.DIST }}
+        echo "start up simulator..."
+        ${{ env.DIST }}/ab_server --plc=PLC/5 --tag=N7[10] &
+        sleep 2
+        echo "test simple get/set tag."
+        ${{ env.DIST }}/tag_rw -t sint16 -p 'protocol=ab_eip&gateway=127.0.0.1&plc=plc5&elem_size=2&elem_count=10&name=N7:0'
+        echo "shut down server."
+        killall ab_server -INT &> /dev/null
+
+    - name: Test SLC 500
+      run: |
+        cd ${{ env.DIST }}
+        echo "start up simulator..."
+        ${{ env.DIST }}/ab_server --plc=SLC500 --tag=N7[10] &
+        sleep 2
+        echo "test simple get/set tag."
+        ${{ env.DIST }}/tag_rw -t sint16 -p 'protocol=ab_eip&gateway=127.0.0.1&plc=slc&elem_size=2&elem_count=10&name=N7:0'
+        echo "shut down server."
+        killall ab_server -INT &> /dev/null
+
+
+    - name: Test Duplicate Connection ID 
+      run: |
+        cd ${{ env.DIST }}
+        echo "start up simulator..."
+        ${{ env.DIST }}/ab_server --plc=ControlLogix --path=1,0 --tag=TestDINTArray:DINT[10] --reject-fo=5 &
+        sleep 2
+        echo "test simple get/set tag."
+        ${{ env.DIST }}/tag_rw -t sint32 -p 'protocol=ab-eip&gateway=127.0.0.1&path=1,0&plc=ControlLogix&name=TestDINTArray'
+        echo "shut down server."
+        killall ab_server -INT &> /dev/null
+
+    - name: Test Large Tags 
+      run: |
+        cd ${{ env.DIST }}
+        echo "start up simulator..."
+        ${{ env.DIST }}/ab_server --plc=ControlLogix --path=1,0 --tag=TestBigArray:DINT[2000] &
+        sleep 2
+        echo "test simple get/set tag."
+        ${{ env.DIST }}/tag_rw -t sint32 -p 'protocol=ab-eip&gateway=127.0.0.1&path=1,0&plc=ControlLogix&elem_count=2000&name=TestDINTArray'
+        echo "shut down server."
+        killall ab_server -INT &> /dev/null
 
     - name: Upload ZIP artifact
       uses: actions/upload-artifact@v1
@@ -221,8 +343,8 @@ jobs:
     runs-on: windows-latest
 
     env:
-      VERSION: "2.1.13"
-      ARTIFACT: "libplctag_2.1.13_windows_x64"
+      VERSION: "2.1.14"
+      ARTIFACT: "libplctag_2.1.14_windows_x64"
       BUILD: "${{ github.workspace }}/build"
       DIST: "${{ github.workspace }}/build/bin_dist"
 
@@ -252,8 +374,8 @@ jobs:
     runs-on: windows-latest
 
     env:
-      VERSION: "2.1.13"
-      ARTIFACT: "libplctag_2.1.13_windows_x86"
+      VERSION: "2.1.14"
+      ARTIFACT: "libplctag_2.1.14_windows_x86"
       BUILD: "${{ github.workspace }}/build"
       DIST: "${{ github.workspace }}/build/bin_dist"
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,7 @@ jobs:
       run: |
         cd ${{ env.DIST }}
         echo "start up simulator..."
-        ${{ env.DIST }}/ab_server --plc=ControlLogix --path=1,0 --tag=TestBigArray:DINT[2000] &
+        ${{ env.DIST }}/ab_server --debug --plc=ControlLogix --path=1,0 --tag=TestBigArray:DINT[2000] &
         sleep 2
         echo "test simple get/set tag."
         ${{ env.DIST }}/simple

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -108,7 +108,7 @@ jobs:
         ${{ env.DIST }}/ab_server --plc=ControlLogix --path=1,0 --tag=TestBigArray:DINT[2000] &
         sleep 2
         echo "test simple get/set tag."
-        ${{ env.DIST }}/tag_rw -t sint32 -p 'protocol=ab-eip&gateway=127.0.0.1&path=1,0&plc=ControlLogix&elem_count=2000&name=TestDINTArray'
+        ${{ env.DIST }}/tag_rw -t sint32 -p 'protocol=ab-eip&gateway=127.0.0.1&path=1,0&plc=ControlLogix&elem_count=2000&name=TestBigArray'
         echo "shut down server."
         killall ab_server -INT &> /dev/null
 
@@ -220,7 +220,7 @@ jobs:
         ${{ env.DIST }}/ab_server --plc=ControlLogix --path=1,0 --tag=TestBigArray:DINT[2000] &
         sleep 2
         echo "test simple get/set tag."
-        ${{ env.DIST }}/tag_rw -t sint32 -p 'protocol=ab-eip&gateway=127.0.0.1&path=1,0&plc=ControlLogix&elem_count=2000&name=TestDINTArray'
+        ${{ env.DIST }}/tag_rw -t sint32 -p 'protocol=ab-eip&gateway=127.0.0.1&path=1,0&plc=ControlLogix&elem_count=2000&name=TestBigArray'
         echo "shut down server."
         killall ab_server -INT &> /dev/null
 
@@ -328,7 +328,7 @@ jobs:
         ${{ env.DIST }}/ab_server --plc=ControlLogix --path=1,0 --tag=TestBigArray:DINT[2000] &
         sleep 2
         echo "test simple get/set tag."
-        ${{ env.DIST }}/tag_rw -t sint32 -p 'protocol=ab-eip&gateway=127.0.0.1&path=1,0&plc=ControlLogix&elem_count=2000&name=TestDINTArray'
+        ${{ env.DIST }}/tag_rw -t sint32 -p 'protocol=ab-eip&gateway=127.0.0.1&path=1,0&plc=ControlLogix&elem_count=2000&name=TestBigArray'
         echo "shut down server."
         killall ab_server -INT &> /dev/null
 

--- a/.github/workflows/ci.yml.in
+++ b/.github/workflows/ci.yml.in
@@ -90,6 +90,28 @@ jobs:
         echo "shut down server."
         killall ab_server -INT &> /dev/null
 
+    - name: Test Duplicate Connection ID 
+      run: |
+        cd ${{ env.DIST }}
+        echo "start up simulator..."
+        ${{ env.DIST }}/ab_server --plc=ControlLogix --path=1,0 --tag=TestDINTArray:DINT[10] --reject-fo=5 &
+        sleep 2
+        echo "test simple get/set tag."
+        ${{ env.DIST }}/tag_rw -t sint32 -p 'protocol=ab-eip&gateway=127.0.0.1&path=1,0&plc=ControlLogix&name=TestDINTArray'
+        echo "shut down server."
+        killall ab_server -INT &> /dev/null
+
+    - name: Test Large Tags 
+      run: |
+        cd ${{ env.DIST }}
+        echo "start up simulator..."
+        ${{ env.DIST }}/ab_server --plc=ControlLogix --path=1,0 --tag=TestBigArray:DINT[2000] &
+        sleep 2
+        echo "test simple get/set tag."
+        ${{ env.DIST }}/tag_rw -t sint32 -p 'protocol=ab-eip&gateway=127.0.0.1&path=1,0&plc=ControlLogix&elem_count=2000&name=TestDINTArray'
+        echo "shut down server."
+        killall ab_server -INT &> /dev/null
+
     - name: Upload ZIP artifact
       uses: actions/upload-artifact@v1
       with:
@@ -122,7 +144,7 @@ jobs:
     - name: Build
       run: cd ${{ env.BUILD }}; cmake --build .
 
-    - name: Test ControlLogix
+    - name: Test Basic Functions
       run: |
         cd ${{ env.DIST }}
         echo "start up simulator..."
@@ -179,6 +201,29 @@ jobs:
         echo "shut down server."
         killall ab_server -INT &> /dev/null
 
+
+    - name: Test Duplicate Connection ID 
+      run: |
+        cd ${{ env.DIST }}
+        echo "start up simulator..."
+        ${{ env.DIST }}/ab_server --plc=ControlLogix --path=1,0 --tag=TestDINTArray:DINT[10] --reject-fo=5 &
+        sleep 2
+        echo "test simple get/set tag."
+        ${{ env.DIST }}/tag_rw -t sint32 -p 'protocol=ab-eip&gateway=127.0.0.1&path=1,0&plc=ControlLogix&name=TestDINTArray'
+        echo "shut down server."
+        killall ab_server -INT &> /dev/null
+
+    - name: Test Large Tags 
+      run: |
+        cd ${{ env.DIST }}
+        echo "start up simulator..."
+        ${{ env.DIST }}/ab_server --plc=ControlLogix --path=1,0 --tag=TestBigArray:DINT[2000] &
+        sleep 2
+        echo "test simple get/set tag."
+        ${{ env.DIST }}/tag_rw -t sint32 -p 'protocol=ab-eip&gateway=127.0.0.1&path=1,0&plc=ControlLogix&elem_count=2000&name=TestDINTArray'
+        echo "shut down server."
+        killall ab_server -INT &> /dev/null
+
     - name: Upload ZIP artifact
       uses: actions/upload-artifact@v1
       with:
@@ -207,8 +252,85 @@ jobs:
     - name: Build
       run: cd ${{ env.BUILD }}; cmake --build .
 
-    - name: Test
-      run: echo "Tests suppressed on macOS."
+    - name: Test Basic Functions
+      run: |
+        cd ${{ env.DIST }}
+        echo "start up simulator..."
+        ${{ env.DIST }}/ab_server --plc=ControlLogix --path=1,0 --tag=TestBigArray:DINT[2000] &
+        sleep 2
+        echo "test simple get/set tag."
+        ${{ env.DIST }}/simple
+        echo "test callback use."
+        ${{ env.DIST }}/test_callback
+        echo "shut down server."
+        killall ab_server -INT &> /dev/null
+
+    - name: Test Micro800
+      run: |
+        cd ${{ env.DIST }}
+        echo "start up simulator..."
+        ${{ env.DIST }}/ab_server --plc=Micro800 --tag=TestDINTArray:DINT[10] &
+        sleep 2
+        echo "test simple get/set tag."
+        ${{ env.DIST }}/tag_rw -t sint32 -p 'protocol=ab_eip&gateway=127.0.0.1&cpu=micro800&elem_size=4&elem_count=1&name=TestDINTArray[0]'
+        echo "shut down server."
+        killall ab_server -INT &> /dev/null
+
+    - name: Test Omron NJ/NX
+      run: |
+        cd ${{ env.DIST }}
+        echo "start up simulator..."
+        ${{ env.DIST }}/ab_server --plc=Omron --tag=TestDINTArray:DINT[10] &
+        sleep 2
+        echo "test simple get/set tag."
+        ${{ env.DIST }}/tag_rw -t sint32 -p 'protocol=ab-eip&gateway=127.0.0.1&path=18,127.0.0.1&plc=omron-njnx&name=TestDINTArray'
+        echo "shut down server."
+        killall ab_server -INT &> /dev/null
+
+    - name: Test PLC/5
+      run: |
+        cd ${{ env.DIST }}
+        echo "start up simulator..."
+        ${{ env.DIST }}/ab_server --plc=PLC/5 --tag=N7[10] &
+        sleep 2
+        echo "test simple get/set tag."
+        ${{ env.DIST }}/tag_rw -t sint16 -p 'protocol=ab_eip&gateway=127.0.0.1&plc=plc5&elem_size=2&elem_count=10&name=N7:0'
+        echo "shut down server."
+        killall ab_server -INT &> /dev/null
+
+    - name: Test SLC 500
+      run: |
+        cd ${{ env.DIST }}
+        echo "start up simulator..."
+        ${{ env.DIST }}/ab_server --plc=SLC500 --tag=N7[10] &
+        sleep 2
+        echo "test simple get/set tag."
+        ${{ env.DIST }}/tag_rw -t sint16 -p 'protocol=ab_eip&gateway=127.0.0.1&plc=slc&elem_size=2&elem_count=10&name=N7:0'
+        echo "shut down server."
+        killall ab_server -INT &> /dev/null
+
+
+    - name: Test Duplicate Connection ID 
+      run: |
+        cd ${{ env.DIST }}
+        echo "start up simulator..."
+        ${{ env.DIST }}/ab_server --plc=ControlLogix --path=1,0 --tag=TestDINTArray:DINT[10] --reject-fo=5 &
+        sleep 2
+        echo "test simple get/set tag."
+        ${{ env.DIST }}/tag_rw -t sint32 -p 'protocol=ab-eip&gateway=127.0.0.1&path=1,0&plc=ControlLogix&name=TestDINTArray'
+        echo "shut down server."
+        killall ab_server -INT &> /dev/null
+
+    - name: Test Large Tags 
+      run: |
+        cd ${{ env.DIST }}
+        echo "start up simulator..."
+        ${{ env.DIST }}/ab_server --plc=ControlLogix --path=1,0 --tag=TestBigArray:DINT[2000] &
+        sleep 2
+        echo "test simple get/set tag."
+        ${{ env.DIST }}/tag_rw -t sint32 -p 'protocol=ab-eip&gateway=127.0.0.1&path=1,0&plc=ControlLogix&elem_count=2000&name=TestDINTArray'
+        echo "shut down server."
+        killall ab_server -INT &> /dev/null
 
     - name: Upload ZIP artifact
       uses: actions/upload-artifact@v1

--- a/.github/workflows/ci.yml.in
+++ b/.github/workflows/ci.yml.in
@@ -37,7 +37,7 @@ jobs:
       run: |
         cd ${{ env.DIST }}
         echo "start up simulator..."
-        ${{ env.DIST }}/ab_server --plc=ControlLogix --path=1,0 --tag=TestBigArray:DINT[2000] &
+        ${{ env.DIST }}/ab_server --debug --plc=ControlLogix --path=1,0 --tag=TestBigArray:DINT[2000] &
         sleep 2
         echo "test simple get/set tag."
         ${{ env.DIST }}/simple

--- a/.github/workflows/ci.yml.in
+++ b/.github/workflows/ci.yml.in
@@ -108,7 +108,7 @@ jobs:
         ${{ env.DIST }}/ab_server --plc=ControlLogix --path=1,0 --tag=TestBigArray:DINT[2000] &
         sleep 2
         echo "test simple get/set tag."
-        ${{ env.DIST }}/tag_rw -t sint32 -p 'protocol=ab-eip&gateway=127.0.0.1&path=1,0&plc=ControlLogix&elem_count=2000&name=TestDINTArray'
+        ${{ env.DIST }}/tag_rw -t sint32 -p 'protocol=ab-eip&gateway=127.0.0.1&path=1,0&plc=ControlLogix&elem_count=2000&name=TestBigArray'
         echo "shut down server."
         killall ab_server -INT &> /dev/null
 
@@ -220,7 +220,7 @@ jobs:
         ${{ env.DIST }}/ab_server --plc=ControlLogix --path=1,0 --tag=TestBigArray:DINT[2000] &
         sleep 2
         echo "test simple get/set tag."
-        ${{ env.DIST }}/tag_rw -t sint32 -p 'protocol=ab-eip&gateway=127.0.0.1&path=1,0&plc=ControlLogix&elem_count=2000&name=TestDINTArray'
+        ${{ env.DIST }}/tag_rw -t sint32 -p 'protocol=ab-eip&gateway=127.0.0.1&path=1,0&plc=ControlLogix&elem_count=2000&name=TestBigArray'
         echo "shut down server."
         killall ab_server -INT &> /dev/null
 
@@ -328,7 +328,7 @@ jobs:
         ${{ env.DIST }}/ab_server --plc=ControlLogix --path=1,0 --tag=TestBigArray:DINT[2000] &
         sleep 2
         echo "test simple get/set tag."
-        ${{ env.DIST }}/tag_rw -t sint32 -p 'protocol=ab-eip&gateway=127.0.0.1&path=1,0&plc=ControlLogix&elem_count=2000&name=TestDINTArray'
+        ${{ env.DIST }}/tag_rw -t sint32 -p 'protocol=ab-eip&gateway=127.0.0.1&path=1,0&plc=ControlLogix&elem_count=2000&name=TestBigArray'
         echo "shut down server."
         killall ab_server -INT &> /dev/null
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,7 +33,7 @@
 # the project is version 2.1
 set (libplctag_VERSION_MAJOR 2)
 set (libplctag_VERSION_MINOR 1)
-set (libplctag_VERSION_PATCH 13)
+set (libplctag_VERSION_PATCH 14)
 set (VERSION "${libplctag_VERSION_MAJOR}.${libplctag_VERSION_MINOR}.${libplctag_VERSION_PATCH}")
 
 set (LIB_NAME_SUFFIX "${libplctag_VERSION_MAJOR}.${libplctag_VERSION_MINOR}.${libplctag_VERSION_PATCH}")

--- a/src/protocols/ab/session.c
+++ b/src/protocols/ab/session.c
@@ -92,15 +92,19 @@ static int prepare_request(ab_session_p session);
 static int send_eip_request(ab_session_p session, int timeout);
 static int recv_eip_response(ab_session_p session, int timeout);
 static int unpack_response(ab_session_p session, ab_request_p request, int sub_packet);
-static int perform_forward_open(ab_session_p session);
+// static int perform_forward_open(ab_session_p session);
 static int perform_forward_close(ab_session_p session);
-static int try_forward_open_ex(ab_session_p session, int *max_payload_size_guess);
-static int try_forward_open(ab_session_p session);
-static int send_forward_open_req(ab_session_p session);
-static int send_forward_open_req_ex(ab_session_p session);
-static int recv_forward_open_resp(ab_session_p session, int *max_payload_size_guess);
+// static int try_forward_open_ex(ab_session_p session, int *max_payload_size_guess);
+// static int try_forward_open(ab_session_p session);
+// static int send_forward_open_req(ab_session_p session);
+// static int send_forward_open_req_ex(ab_session_p session);
+// static int recv_forward_open_resp(ab_session_p session, int *max_payload_size_guess);
 static int send_forward_close_req(ab_session_p session);
 static int recv_forward_close_resp(ab_session_p session);
+static int send_forward_open_request(ab_session_p session);
+static int send_old_forward_open_request(ab_session_p session);
+static int send_extended_forward_open_request(ab_session_p session);
+static int receive_forward_open_response(ab_session_p session);
 static void request_destroy(void *req_arg);
 static int session_request_increase_buffer(ab_request_p request, int new_capacity);
 
@@ -945,10 +949,10 @@ int session_remove_request_unsafe(ab_session_p session, ab_request_p req)
  ****************************************************************/
 
 
-typedef enum { SESSION_OPEN_SOCKET, SESSION_REGISTER, SESSION_CONNECT,
-               SESSION_IDLE, SESSION_DISCONNECT, SESSION_UNREGISTER,
-               SESSION_CLOSE_SOCKET, SESSION_START_RETRY, SESSION_WAIT_RETRY,
-               SESSION_WAIT_RECONNECT
+typedef enum { SESSION_OPEN_SOCKET, SESSION_REGISTER, SESSION_SEND_FORWARD_OPEN,
+               SESSION_RECEIVE_FORWARD_OPEN, SESSION_IDLE, SESSION_DISCONNECT, 
+               SESSION_UNREGISTER, SESSION_CLOSE_SOCKET, SESSION_START_RETRY, 
+               SESSION_WAIT_RETRY, SESSION_WAIT_RECONNECT
              } session_state_t;
 
 
@@ -1005,24 +1009,49 @@ THREAD_FUNC(session_handler)
                 state = SESSION_CLOSE_SOCKET;
             } else {
                 if(session->use_connected_msg) {
-                    state = SESSION_CONNECT;
+                    state = SESSION_SEND_FORWARD_OPEN;
                 } else {
                     state = SESSION_IDLE;
                 }
             }
             break;
 
-        case SESSION_CONNECT:
-            pdebug(DEBUG_DETAIL, "in SESSION_CONNECT state.");
+        case SESSION_SEND_FORWARD_OPEN:
+            pdebug(DEBUG_DETAIL, "in SESSION_SEND_FORWARD_OPEN state.");
 
-            if((rc = perform_forward_open(session)) != PLCTAG_STATUS_OK) {
-                pdebug(DEBUG_WARN, "Forward open failed %s!", plc_tag_decode_error(rc));
+            if((rc = send_forward_open_request(session)) != PLCTAG_STATUS_OK) {
+                pdebug(DEBUG_WARN, "Send Forward Open failed %s!", plc_tag_decode_error(rc));
                 state = SESSION_UNREGISTER;
             } else {
-                pdebug(DEBUG_DETAIL, "forward open succeeded, going to idle state.");
-                state = SESSION_IDLE;
+                pdebug(DEBUG_DETAIL, "Send Forward Open succeeded, going to SESSION_RECEIVE_FORWARD_OPEN state.");
+                state = SESSION_RECEIVE_FORWARD_OPEN;
             }
             break;
+
+        case SESSION_RECEIVE_FORWARD_OPEN:
+            pdebug(DEBUG_DETAIL, "in SESSION_RECEIVE_FORWARD_OPEN state.");
+
+            if((rc = receive_forward_open_response(session)) != PLCTAG_STATUS_OK) {
+                if(rc == PLCTAG_ERR_DUPLICATE) {
+                    pdebug(DEBUG_DETAIL, "Duplicate connection error received, trying again with different connection ID.");
+                    state = SESSION_SEND_FORWARD_OPEN;
+                } else if(rc == PLCTAG_ERR_TOO_LARGE) {
+                    pdebug(DEBUG_DETAIL, "Requested packet size too large, retrying with smaller size.");
+                    state = SESSION_SEND_FORWARD_OPEN;
+                } else if(rc == PLCTAG_ERR_UNSUPPORTED && !session->only_use_old_forward_open) {
+                    /* if we got an unsupported error and we are trying with ForwardOpenEx, then try the old command. */
+                    pdebug(DEBUG_DETAIL, "PLC does not support ForwardOpenEx, trying old ForwardOpen.");
+                    session->only_use_old_forward_open = 1;
+                    state = SESSION_SEND_FORWARD_OPEN;
+                } else {
+                    pdebug(DEBUG_WARN, "Receive Forward Open failed %s!", plc_tag_decode_error(rc));
+                    state = SESSION_UNREGISTER;
+                }
+            } else {
+                pdebug(DEBUG_DETAIL, "Send Forward Open succeeded, going to SESSION_IDLE state.");
+                state = SESSION_IDLE;
+            }
+            break;        
 
         case SESSION_IDLE:
             pdebug(DEBUG_SPEW, "in SESSION_IDLE state.");
@@ -1869,62 +1898,6 @@ int recv_eip_response(ab_session_p session, int timeout)
 
 
 
-int perform_forward_open(ab_session_p session)
-{
-    int rc = PLCTAG_STATUS_OK;
-    int max_payload_size = session->max_payload_size;
-
-    pdebug(DEBUG_INFO, "Starting.");
-
-    do {
-        /*
-         * Try with a large packet if this is a Logix-class PLC
-         * and we are doing connected messaging.
-         */
-
-        if(session->plc_type == AB_PLC_LGX && session->use_connected_msg) {
-            max_payload_size = MAX_CIP_MSG_SIZE_EX;
-        }
-
-        rc = try_forward_open_ex(session, &max_payload_size);
-        if(rc == PLCTAG_ERR_TOO_LARGE) {
-            /* we support the Forward Open Extended command, but we need to use a smaller size. */
-            pdebug(DEBUG_DETAIL, "ForwardOpenEx is supported but packet size of %d is not, trying %d.", MAX_CIP_MSG_SIZE_EX, max_payload_size);
-
-            rc = try_forward_open_ex(session, &max_payload_size);
-            if(rc != PLCTAG_STATUS_OK) {
-                pdebug(DEBUG_WARN, "Unable to open connection to PLC (%s)!", plc_tag_decode_error(rc));
-            } else {
-                pdebug(DEBUG_INFO, "ForwardOpenEx succeeded with packet size %d.", session->max_payload_size);
-            }
-        } else if(rc == PLCTAG_ERR_UNSUPPORTED) {
-            rc = try_forward_open(session);
-            if(rc == PLCTAG_ERR_TOO_LARGE) {
-                /* we support the Forward Open Extended command, but we need to use a smaller size. */
-                pdebug(DEBUG_INFO, "ForwardOpen is supported but packet size of %d is not, trying %d.", MAX_CIP_MSG_SIZE, session->max_payload_size);
-
-                rc = try_forward_open(session);
-                if(rc != PLCTAG_STATUS_OK) {
-                    pdebug(DEBUG_WARN, "Unable to open connection to PLC (%s)!", plc_tag_decode_error(rc));
-                } else {
-                    pdebug(DEBUG_INFO, "ForwardOpen succeeded with packet size %d.", session->max_payload_size);
-                }
-            }
-        } /*else {
-            pdebug(DEBUG_WARN, "Unknown error! rc=%d", rc);
-        }*/
-    } while(0);
-
-    if(rc == PLCTAG_STATUS_OK) {
-        pdebug(DEBUG_INFO, "ForwardOpen succeeded and maximum CIP packet size is %d.", session->max_payload_size);
-    }
-
-    pdebug(DEBUG_INFO, "Done.");
-
-    return rc;
-}
-
-
 int perform_forward_close(ab_session_p session)
 {
     int rc = PLCTAG_STATUS_OK;
@@ -1951,101 +1924,45 @@ int perform_forward_close(ab_session_p session)
 }
 
 
-int try_forward_open_ex(ab_session_p session, int *packet_size_guess)
+
+int send_forward_open_request(ab_session_p session)
 {
     int rc = PLCTAG_STATUS_OK;
-    ab_request_p req=NULL;
-    uint16_t old_max_payload_size = 0;
 
+    pdebug(DEBUG_INFO, "Starting");
 
-    pdebug(DEBUG_INFO, "Starting.");
+    /* if this is the first time we are called set up a default guess size. */
+    if(!session->max_payload_guess) {
+        if(session->plc_type == AB_PLC_LGX && session->use_connected_msg && !session->only_use_old_forward_open) {
+            session->max_payload_guess = MAX_CIP_MSG_SIZE_EX;
+        } else {
+            session->max_payload_guess = session->max_payload_size;
+        }
 
-    critical_block(session->mutex) {
-        old_max_payload_size = session->max_payload_size;
-        session->max_payload_size = (uint16_t)*packet_size_guess;
+        pdebug(DEBUG_DETAIL, "Setting initial payload size guess to %u.", (unsigned int)session->max_payload_guess);
     }
 
-    /* get a request buffer */
-    rc = session_create_request(session, 0, &req);
-
-    do {
-        if(rc != PLCTAG_STATUS_OK) {
-            pdebug(DEBUG_WARN, "Unable to get new request, %s!", plc_tag_decode_error(rc));
-            rc = 0;
-            break;
-        }
-
-        /* send the ForwardOpenEx command to the PLC */
-        if((rc = send_forward_open_req_ex(session)) != PLCTAG_STATUS_OK) {
-            pdebug(DEBUG_WARN, "Unable to send ForwardOpenEx packet!");
-            break;
-        }
-
-        /* check for the ForwardOpen response. */
-        if((rc = recv_forward_open_resp(session, packet_size_guess)) != PLCTAG_STATUS_OK) {
-            pdebug(DEBUG_WARN, "Unable to use ForwardOpen response!");
-            break;
-        }
-    } while(0);
-
-    if(req) {
-        req = rc_dec(req);
+    /* 
+     * double check the message size.   If we just transitioned to using the old ForwardOpen command
+     * then the maximum payload guess might be too large.
+     */
+    if(session->plc_type == AB_PLC_LGX && session->only_use_old_forward_open && session->max_payload_guess > MAX_CIP_MSG_SIZE) {
+        session->max_payload_guess = MAX_CIP_MSG_SIZE;
     }
 
-    if(rc != PLCTAG_STATUS_OK) {
-        critical_block(session->mutex) {
-            session->max_payload_size = old_max_payload_size;
-        }
+    if(session->only_use_old_forward_open) {
+        rc = send_old_forward_open_request(session);
+    } else {
+        rc = send_extended_forward_open_request(session);
     }
 
-    pdebug(DEBUG_INFO, "Done.");
+    pdebug(DEBUG_INFO, "Done");
 
     return rc;
 }
 
 
-int try_forward_open(ab_session_p session)
-{
-    int rc = PLCTAG_STATUS_OK;
-    ab_request_p req=NULL;
-
-    pdebug(DEBUG_INFO, "Starting.");
-
-    /* get a request buffer */
-    rc = session_create_request(session, 0, &req);
-
-    do {
-        if(rc != PLCTAG_STATUS_OK) {
-            pdebug(DEBUG_WARN, "Unable to get new request, %s!", plc_tag_decode_error(rc));
-            rc = 0;
-            break;
-        }
-
-        /* send the ForwardOpen command to the PLC */
-        if((rc = send_forward_open_req(session)) != PLCTAG_STATUS_OK) {
-            pdebug(DEBUG_WARN, "Unable to send ForwardOpenEx packet!");
-            break;
-        }
-
-        /* check for the ForwardOpen response. */
-        if((rc = recv_forward_open_resp(session, NULL)) != PLCTAG_STATUS_OK) {
-            pdebug(DEBUG_WARN, "Unable to use ForwardOpen response!");
-            break;
-        }
-    } while(0);
-
-    if(req) {
-        req = rc_dec(req);
-    }
-
-    pdebug(DEBUG_INFO, "Done.");
-
-    return rc;
-}
-
-
-
-int send_forward_open_req(ab_session_p session)
+int send_old_forward_open_request(ab_session_p session)
 {
     eip_forward_open_request_t *fo = NULL;
     uint8_t *data;
@@ -2105,7 +2022,7 @@ int send_forward_open_req(ab_session_p session)
     if((session->plc_type == AB_PLC_PLC5 || session->plc_type == AB_PLC_SLC || session->plc_type == AB_PLC_MLGX) && session->dhp_dest != 0) {
         fo->orig_to_targ_conn_params = h2le16(AB_EIP_PLC5_PARAM);
     } else {
-        fo->orig_to_targ_conn_params = h2le16(AB_EIP_CONN_PARAM | session->max_payload_size); /* packet size and some other things, based on protocol/cpu type */
+        fo->orig_to_targ_conn_params = h2le16(AB_EIP_CONN_PARAM | session->max_payload_guess); /* packet size and some other things, based on protocol/cpu type */
     }
 
     fo->targ_to_orig_rpi = h2le32(AB_EIP_RPI); /* target to us RPI - not really used for explicit messages? */
@@ -2114,7 +2031,7 @@ int send_forward_open_req(ab_session_p session)
     if((session->plc_type == AB_PLC_PLC5 || session->plc_type == AB_PLC_SLC || session->plc_type == AB_PLC_MLGX) && session->dhp_dest != 0) {
         fo->targ_to_orig_conn_params = h2le16(AB_EIP_PLC5_PARAM);
     } else {
-        fo->targ_to_orig_conn_params = h2le16(AB_EIP_CONN_PARAM | session->max_payload_size); /* packet size and some other things, based on protocol/cpu type */
+        fo->targ_to_orig_conn_params = h2le16(AB_EIP_CONN_PARAM | session->max_payload_guess); /* packet size and some other things, based on protocol/cpu type */
     }
 
     fo->transport_class = AB_EIP_TRANSPORT_CLASS_T3; /* 0xA3, server transport, class 3, application trigger */
@@ -2132,7 +2049,7 @@ int send_forward_open_req(ab_session_p session)
 
 
 /* new version of Forward Open */
-int send_forward_open_req_ex(ab_session_p session)
+int send_extended_forward_open_request(ab_session_p session)
 {
     eip_forward_open_request_ex_t *fo = NULL;
     uint8_t *data;
@@ -2186,9 +2103,9 @@ int send_forward_open_req_ex(ab_session_p session)
     fo->orig_serial_number = h2le32(AB_EIP_VENDOR_SN);           /* our serial number. */
     fo->conn_timeout_multiplier = AB_EIP_TIMEOUT_MULTIPLIER;     /* timeout = mult * RPI */
     fo->orig_to_targ_rpi = h2le32(AB_EIP_RPI); /* us to target RPI - Request Packet Interval in microseconds */
-    fo->orig_to_targ_conn_params_ex = h2le32(AB_EIP_CONN_PARAM_EX | session->max_payload_size); /* packet size and some other things, based on protocol/cpu type */
+    fo->orig_to_targ_conn_params_ex = h2le32(AB_EIP_CONN_PARAM_EX | session->max_payload_guess); /* packet size and some other things, based on protocol/cpu type */
     fo->targ_to_orig_rpi = h2le32(AB_EIP_RPI); /* target to us RPI - not really used for explicit messages? */
-    fo->targ_to_orig_conn_params_ex = h2le32(AB_EIP_CONN_PARAM_EX | session->max_payload_size); /* packet size and some other things, based on protocol/cpu type */
+    fo->targ_to_orig_conn_params_ex = h2le32(AB_EIP_CONN_PARAM_EX | session->max_payload_guess); /* packet size and some other things, based on protocol/cpu type */
     fo->transport_class = AB_EIP_TRANSPORT_CLASS_T3; /* 0xA3, server transport, class 3, application trigger */
     fo->path_size = session->conn_path_size/2; /* size in 16-bit words */
 
@@ -2205,7 +2122,7 @@ int send_forward_open_req_ex(ab_session_p session)
 
 
 
-int recv_forward_open_resp(ab_session_p session, int *max_payload_size_guess)
+int receive_forward_open_response(ab_session_p session)
 {
     eip_forward_open_response_t *fo_resp;
     int rc = PLCTAG_STATUS_OK;
@@ -2236,26 +2153,30 @@ int recv_forward_open_resp(ab_session_p session, int *max_payload_size_guess)
         if(fo_resp->general_status != AB_EIP_OK) {
             pdebug(DEBUG_WARN, "Forward Open command failed, response code: %s (%d)", decode_cip_error_short(&fo_resp->general_status), fo_resp->general_status);
             if(fo_resp->general_status == AB_CIP_ERR_UNSUPPORTED_SERVICE) {
+                /* this type of command is not supported! */
+                pdebug(DEBUG_WARN, "Received CIP command unsupported error from the PLC!");
                 rc = PLCTAG_ERR_UNSUPPORTED;
             } else {
                 rc = PLCTAG_ERR_REMOTE_ERR;
 
-                if(max_payload_size_guess && fo_resp->general_status == 0x01 && fo_resp->status_size >= 2) {
+                if(fo_resp->general_status == 0x01 && fo_resp->status_size >= 2) {
                     /* we might have an error that tells us the actual size to use. */
                     uint8_t *data = &fo_resp->status_size;
                     int extended_status = data[1] | (data[2] << 8);
-                    int supported_size = data[3] | (data[4] << 8);
+                    uint16_t supported_size = (uint16_t)((uint16_t)data[3] | (uint16_t)((uint16_t)data[4] << (uint16_t)8));
 
                     if(extended_status == 0x109) { /* MAGIC */
                         pdebug(DEBUG_WARN, "Error from forward open request, unsupported size, but size %d is supported.", supported_size);
-                        //session->max_payload_size = (uint16_t)supported_size;
-                        *max_payload_size_guess = supported_size;
+                        session->max_payload_guess = supported_size;
                         rc = PLCTAG_ERR_TOO_LARGE;
+                    } else if(extended_status == 0x100) { /* MAGIC */
+                        pdebug(DEBUG_WARN, "Error from forward open request, duplicate connection ID.  Need to try again.");
+                        rc = PLCTAG_ERR_DUPLICATE;
                     } else {
-                        pdebug(DEBUG_WARN, "CIP extended error %x!", extended_status);
+                        pdebug(DEBUG_WARN, "CIP extended error %s (%s)!", decode_cip_error_short(&fo_resp->general_status), decode_cip_error_long(&fo_resp->general_status));
                     }
                 } else {
-                    pdebug(DEBUG_WARN, "CIP error code %x!", fo_resp->general_status);
+                    pdebug(DEBUG_WARN, "CIP error code %s (%s)!", decode_cip_error_short(&fo_resp->general_status), decode_cip_error_long(&fo_resp->general_status));
                 }
             }
 
@@ -2266,7 +2187,9 @@ int recv_forward_open_resp(ab_session_p session, int *max_payload_size_guess)
         session->targ_connection_id = le2h32(fo_resp->orig_to_targ_conn_id);
         session->orig_connection_id = le2h32(fo_resp->targ_to_orig_conn_id);
 
-        pdebug(DEBUG_INFO, "ForwardOpen succeeded with our connection ID %x and the PLC connection ID %x", session->orig_connection_id, session->targ_connection_id);
+        session->max_payload_size = session->max_payload_guess;
+
+        pdebug(DEBUG_INFO, "ForwardOpen succeeded with our connection ID %x and the PLC connection ID %x with packet size %u.", session->orig_connection_id, session->targ_connection_id, session->max_payload_size);
 
         rc = PLCTAG_STATUS_OK;
     } while(0);

--- a/src/protocols/ab/session.h
+++ b/src/protocols/ab/session.h
@@ -62,6 +62,8 @@ struct ab_session_t {
 
     /* connection variables. */
     int use_connected_msg;
+    int only_use_old_forward_open;
+    uint16_t max_payload_guess;
     uint32_t orig_connection_id;
     uint32_t targ_connection_id;
     uint16_t conn_seq_num;

--- a/src/tests/ab_server/src/cip.c
+++ b/src/tests/ab_server/src/cip.c
@@ -208,8 +208,8 @@ slice_s handle_forward_open(slice_s input, slice_s output, plc_s *plc)
 
     /* check to see how many refusals we should do. */
     if(plc->reject_fo_count > 0) {
-        info("Forward open request being bounced for debugging.");
         plc->reject_fo_count--;
+        info("Forward open request being bounced for debugging. %d to go.", plc->reject_fo_count);
         return make_cip_error(output, 
                              (uint8_t)(slice_get_uint8(input, 0) | CIP_DONE),
                              (uint8_t)CIP_ERR_0x01,

--- a/src/tests/ab_server/src/cip.c
+++ b/src/tests/ab_server/src/cip.c
@@ -207,8 +207,9 @@ slice_s handle_forward_open(slice_s input, slice_s output, plc_s *plc)
     }
 
     /* check to see how many refusals we should do. */
-    if(plc->reject_fo_count--) {
+    if(plc->reject_fo_count > 0) {
         info("Forward open request being bounced for debugging.");
+        plc->reject_fo_count--;
         return make_cip_error(output, 
                              (uint8_t)(slice_get_uint8(input, 0) | CIP_DONE),
                              (uint8_t)CIP_ERR_0x01,

--- a/src/tests/ab_server/src/cip.c
+++ b/src/tests/ab_server/src/cip.c
@@ -70,6 +70,7 @@ const uint8_t CIP_FORWARD_OPEN_EX[] = { 0x5B, 0x02, 0x20, 0x06, 0x24, 0x01 };
 /* CIP Errors */
 
 #define CIP_OK                  ((uint8_t)0x00)
+#define CIP_ERR_0x01            ((uint8_t)0x01)
 #define CIP_ERR_FRAG            ((uint8_t)0x06)
 #define CIP_ERR_UNSUPPORTED     ((uint8_t)0x08)
 #define CIP_ERR_EXTENDED        ((uint8_t)0xff)
@@ -203,6 +204,16 @@ slice_s handle_forward_open(slice_s input, slice_s output, plc_s *plc)
         /* FIXME - send back the right error. */
         info("Forward open request path did not match the path for this PLC!");
         return make_cip_error(output, (uint8_t)(slice_get_uint8(input, 0) | CIP_DONE), (uint8_t)CIP_ERR_UNSUPPORTED, false, (uint16_t)0);
+    }
+
+    /* check to see how many refusals we should do. */
+    if(plc->reject_fo_count--) {
+        info("Forward open request being bounced for debugging.");
+        return make_cip_error(output, 
+                             (uint8_t)(slice_get_uint8(input, 0) | CIP_DONE),
+                             (uint8_t)CIP_ERR_0x01,
+                             true,
+                             (uint16_t)0x100);
     }
 
     /* all good if we got here. */

--- a/src/tests/ab_server/src/main.c
+++ b/src/tests/ab_server/src/main.c
@@ -214,6 +214,9 @@ void process_args(int argc, const char **argv, plc_s *plc)
     bool has_plc = false;
     bool has_tag = false;
 
+    /* make sure that the reject FO count is zero. */
+    plc->reject_fo_count = 0;
+
     for(int i=0; i < argc; i++) {
         if(strncmp(argv[i],"--plc=",6) == 0) {
             if(has_plc) {

--- a/src/tests/ab_server/src/main.c
+++ b/src/tests/ab_server/src/main.c
@@ -329,7 +329,13 @@ void process_args(int argc, const char **argv, plc_s *plc)
 
         if(strcmp(argv[i],"--debug") == 0) {
             debug_on();
-            has_tag = true;
+        }
+
+        if(strncmp(argv[i],"--reject_fo=", 12) == 0) {
+            if(plc) {
+                info("Setting reject ForwardOpen count to %d.", atoi(&argv[i][12]));
+                plc->reject_fo_count = atoi(&argv[i][12]);
+            }
         }
     }
 

--- a/src/tests/ab_server/src/plc.h
+++ b/src/tests/ab_server/src/plc.h
@@ -104,6 +104,9 @@ typedef struct {
     /* PCCC info */
     uint16_t pccc_seq_id;
 
+    /* debugging. */
+    int reject_fo_count;
+
     /* list of tags served by this "PLC" */
     struct tag_def_s *tags;
 } plc_s;


### PR DESCRIPTION
This changes how ForwardOpen is done.

- If the PLC is a ControlLogix, then ForwardOpenEx is attempted with a large packet size.
- If that fails due to ForwardOpenEx being unsupported, then the session's state is marked so that FOEx is not attempted again.   Then the library immediately retries.
- If there is a failure due to a duplicate connection sequence number (global in the PLC and only 16-bit!), then the connection ID is incremented and the FO is tried again.   Repeat until timeout or success.

The CI tests have been extended:

- Linux tests include testing multiple FO attempts with different connection IDs via an update to the ab_server simulator.
- Linux tests now include testing very large tags to help catch regressions like the Omron patch created.
- All CI tests added to the macOS job.
