### PR TITLE
Fix 188 - Modbus can only have one request in flight at a time per TCP connection.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,8 +12,8 @@ jobs:
     runs-on: ubuntu-latest
 
     env:
-      VERSION: "2.1.15"
-      ARTIFACT: "libplctag_2.1.15_ubuntu_x64"
+      VERSION: "2.1.16"
+      ARTIFACT: "libplctag_2.1.16_ubuntu_x64"
       BUILD: "${{ github.workspace }}/build"
       DIST: "${{ github.workspace }}/build/bin_dist"
 
@@ -124,8 +124,8 @@ jobs:
     runs-on: ubuntu-latest
 
     env:
-      VERSION: "2.1.15"
-      ARTIFACT: "libplctag_2.1.15_ubuntu_x86"
+      VERSION: "2.1.16"
+      ARTIFACT: "libplctag_2.1.16_ubuntu_x86"
       BUILD: "${{ github.workspace }}/build"
       DIST: "${{ github.workspace }}/build/bin_dist"
 
@@ -235,8 +235,8 @@ jobs:
     runs-on: macos-latest
 
     env:
-      VERSION: "2.1.15"
-      ARTIFACT: "libplctag_2.1.15_macos_x64"
+      VERSION: "2.1.16"
+      ARTIFACT: "libplctag_2.1.16_macos_x64"
       BUILD: "${{ github.workspace }}/build"
       DIST: "${{ github.workspace }}/build/bin_dist"
 
@@ -342,8 +342,8 @@ jobs:
     runs-on: windows-latest
 
     env:
-      VERSION: "2.1.15"
-      ARTIFACT: "libplctag_2.1.15_windows_x64"
+      VERSION: "2.1.16"
+      ARTIFACT: "libplctag_2.1.16_windows_x64"
       BUILD: "${{ github.workspace }}\\build"
       DIST: "${{ github.workspace }}\\build\\bin_dist"
 
@@ -457,8 +457,8 @@ jobs:
     runs-on: windows-latest
 
     env:
-      VERSION: "2.1.15"
-      ARTIFACT: "libplctag_2.1.15_windows_x86"
+      VERSION: "2.1.16"
+      ARTIFACT: "libplctag_2.1.16_windows_x86"
       BUILD: "${{ github.workspace }}/build"
       DIST: "${{ github.workspace }}/build/bin_dist"
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,7 +33,7 @@
 # the project is version 2.1
 set (libplctag_VERSION_MAJOR 2)
 set (libplctag_VERSION_MINOR 1)
-set (libplctag_VERSION_PATCH 15)
+set (libplctag_VERSION_PATCH 16)
 set (VERSION "${libplctag_VERSION_MAJOR}.${libplctag_VERSION_MINOR}.${libplctag_VERSION_PATCH}")
 
 set (LIB_NAME_SUFFIX "${libplctag_VERSION_MAJOR}.${libplctag_VERSION_MINOR}.${libplctag_VERSION_PATCH}")


### PR DESCRIPTION
Modbus appears to have a restriction that it can only have one request at a time in flight per TCP connection.   This set of changes creates a guard preventing new requests from being created if there is one in flight.