### PR TITLE
set auto_sync_last_read as time_ms()

### DIFF
--- a/src/lib/lib.c
+++ b/src/lib/lib.c
@@ -299,6 +299,7 @@ THREAD_FUNC(tag_tickler_func)
 
                             /* if we have automatic read enabled, make sure we set up correct times. */
                             if(tag->auto_sync_read_ms > 0) {
+                                /* calculate elapsed_sync_peroids instead using current time to avoid read times drift*/
                                 int64_t elapsed_sync_peroids = (time_ms() - tag->auto_sync_last_read) / tag->auto_sync_read_ms;
                                 tag->auto_sync_last_read += elapsed_sync_peroids * tag->auto_sync_read_ms;
                             }

--- a/src/lib/lib.c
+++ b/src/lib/lib.c
@@ -299,13 +299,7 @@ THREAD_FUNC(tag_tickler_func)
 
                             /* if we have automatic read enabled, make sure we set up correct times. */
                             if(tag->auto_sync_read_ms > 0) {
-                                /* when do we read again? */
-                                tag->auto_sync_last_read += tag->auto_sync_read_ms;
-
-                                /* if we are behind, catch up by pushing the next read out. */
-                                if(tag->auto_sync_last_read <= time_ms()) {
-                                    tag->auto_sync_last_read = time_ms() + tag->auto_sync_read_ms;
-                                }
+                                tag->auto_sync_last_read = time_ms();
                             }
 
                             events[PLCTAG_EVENT_READ_COMPLETED] = 1;

--- a/src/lib/lib.c
+++ b/src/lib/lib.c
@@ -299,7 +299,8 @@ THREAD_FUNC(tag_tickler_func)
 
                             /* if we have automatic read enabled, make sure we set up correct times. */
                             if(tag->auto_sync_read_ms > 0) {
-                                tag->auto_sync_last_read = time_ms();
+                                int64_t elapsed_sync_peroids = (time_ms() - tag->auto_sync_last_read) / tag->auto_sync_read_ms;
+                                tag->auto_sync_last_read += elapsed_sync_peroids * tag->auto_sync_read_ms;
                             }
 
                             events[PLCTAG_EVENT_READ_COMPLETED] = 1;


### PR DESCRIPTION
When reading takes 1 ms or more  _we are pushing the next read out_.

It seems that the read time even on the local network can be more than 1ms which means the actual sync period is 2 * auto_sync_read_ms.

I suggest using the time at the end of the reading.
**Update:**
We check the condition `if(tag->auto_sync_last_read + tag->auto_sync_read_ms <= time_ms())` to start reading, that means _we are_ always _behind_ even if the reading time is 0.