### PR TITLE
Fix logging callback debug level

### DIFF
--- a/src/util/debug.c
+++ b/src/util/debug.c
@@ -205,7 +205,7 @@ extern void pdebug_impl(const char *func, int line_num, int debug_level, const c
     /* FIXME - check the output size */
     /*output_size = */vsnprintf(output, sizeof(output), prefix, va);
     if(log_callback_func) {
-        log_callback_func(tag_id, get_debug_level(), output);
+        log_callback_func(tag_id, debug_level, output);
     } else {
         fputs(output, stderr);
     }


### PR DESCRIPTION
The logging callback is currently passed the global debug level (or verbosity). Is this intentional? 

It would be much more useful if the actual debug level of the current message were passed instead.