### PR TITLE
replace the special (non minus) char with a minus - this makes string output nice on windows

### DIFF
--- a/src/examples/list_tags.c
+++ b/src/examples/list_tags.c
@@ -556,16 +556,16 @@ void print_element_type(uint16_t element_type)
 
         switch(atomic_type) {
             case 0xC1: type = "BOOL: Boolean value"; break;
-            case 0xC2: type = "SINT: Signed 8–bit integer value"; break;
-            case 0xC3: type = "INT: Signed 16–bit integer value"; break;
-            case 0xC4: type = "DINT: Signed 32–bit integer value"; break;
-            case 0xC5: type = "LINT: Signed 64–bit integer value"; break;
-            case 0xC6: type = "USINT: Unsigned 8–bit integer value"; break;
-            case 0xC7: type = "UINT: Unsigned 16–bit integer value"; break;
-            case 0xC8: type = "UDINT: Unsigned 32–bit integer value"; break;
-            case 0xC9: type = "ULINT: Unsigned 64–bit integer value"; break;
-            case 0xCA: type = "32–bit floating point value, IEEE format"; break;
-            case 0xCB: type = "64–bit floating point value, IEEE format"; break;
+            case 0xC2: type = "SINT: Signed 8-bit integer value"; break;
+            case 0xC3: type = "INT: Signed 16-bit integer value"; break;
+            case 0xC4: type = "DINT: Signed 32-bit integer value"; break;
+            case 0xC5: type = "LINT: Signed 64-bit integer value"; break;
+            case 0xC6: type = "USINT: Unsigned 8-bit integer value"; break;
+            case 0xC7: type = "UINT: Unsigned 16-bit integer value"; break;
+            case 0xC8: type = "UDINT: Unsigned 32-bit integer value"; break;
+            case 0xC9: type = "ULINT: Unsigned 64-bit integer value"; break;
+            case 0xCA: type = "32-bit floating point value, IEEE format"; break;
+            case 0xCB: type = "64-bit floating point value, IEEE format"; break;
             case 0xCC: type = "Synchronous time value"; break;
             case 0xCD: type = "Date value"; break;
             case 0xCE: type = "Time of day value"; break;

--- a/src/protocols/ab/defs.h
+++ b/src/protocols/ab/defs.h
@@ -143,16 +143,16 @@
 
 /* base data type byte values */
 #define AB_CIP_DATA_BIT         ((uint8_t)0xC1) /* Boolean value, 1 bit */
-#define AB_CIP_DATA_SINT        ((uint8_t)0xC2) /* Signed 8–bit integer value */
-#define AB_CIP_DATA_INT         ((uint8_t)0xC3) /* Signed 16–bit integer value */
-#define AB_CIP_DATA_DINT        ((uint8_t)0xC4) /* Signed 32–bit integer value */
-#define AB_CIP_DATA_LINT        ((uint8_t)0xC5) /* Signed 64–bit integer value */
-#define AB_CIP_DATA_USINT       ((uint8_t)0xC6) /* Unsigned 8–bit integer value */
-#define AB_CIP_DATA_UINT        ((uint8_t)0xC7) /* Unsigned 16–bit integer value */
-#define AB_CIP_DATA_UDINT       ((uint8_t)0xC8) /* Unsigned 32–bit integer value */
-#define AB_CIP_DATA_ULINT       ((uint8_t)0xC9) /* Unsigned 64–bit integer value */
-#define AB_CIP_DATA_REAL        ((uint8_t)0xCA) /* 32–bit floating point value, IEEE format */
-#define AB_CIP_DATA_LREAL       ((uint8_t)0xCB) /* 64–bit floating point value, IEEE format */
+#define AB_CIP_DATA_SINT        ((uint8_t)0xC2) /* Signed 8-bit integer value */
+#define AB_CIP_DATA_INT         ((uint8_t)0xC3) /* Signed 16-bit integer value */
+#define AB_CIP_DATA_DINT        ((uint8_t)0xC4) /* Signed 32-bit integer value */
+#define AB_CIP_DATA_LINT        ((uint8_t)0xC5) /* Signed 64-bit integer value */
+#define AB_CIP_DATA_USINT       ((uint8_t)0xC6) /* Unsigned 8-bit integer value */
+#define AB_CIP_DATA_UINT        ((uint8_t)0xC7) /* Unsigned 16-bit integer value */
+#define AB_CIP_DATA_UDINT       ((uint8_t)0xC8) /* Unsigned 32-bit integer value */
+#define AB_CIP_DATA_ULINT       ((uint8_t)0xC9) /* Unsigned 64-bit integer value */
+#define AB_CIP_DATA_REAL        ((uint8_t)0xCA) /* 32-bit floating point value, IEEE format */
+#define AB_CIP_DATA_LREAL       ((uint8_t)0xCB) /* 64-bit floating point value, IEEE format */
 #define AB_CIP_DATA_STIME       ((uint8_t)0xCC) /* Synchronous time value */
 #define AB_CIP_DATA_DATE        ((uint8_t)0xCD) /* Date value */
 #define AB_CIP_DATA_TIME_OF_DAY ((uint8_t)0xCE) /* Time of day value */

--- a/src/tests/ab_server/src/plc.h
+++ b/src/tests/ab_server/src/plc.h
@@ -40,22 +40,22 @@
 typedef uint16_t tag_type_t;
 
 /* CIP data types. */
-#define TAG_CIP_TYPE_SINT        ((tag_type_t)0x00C2) /* Signed 8–bit integer value */
-#define TAG_CIP_TYPE_INT         ((tag_type_t)0x00C3) /* Signed 16–bit integer value */
-#define TAG_CIP_TYPE_DINT        ((tag_type_t)0x00C4) /* Signed 32–bit integer value */
-#define TAG_CIP_TYPE_LINT        ((tag_type_t)0x00C5) /* Signed 64–bit integer value */
-#define TAG_CIP_TYPE_USINT       ((tag_type_t)0x00C6) /* Unsigned 8–bit integer value */
-#define TAG_CIP_TYPE_UINT        ((tag_type_t)0x00C7) /* Unsigned 16–bit integer value */
-#define TAG_CIP_TYPE_UDINT       ((tag_type_t)0x00C8) /* Unsigned 32–bit integer value */
-#define TAG_CIP_TYPE_ULINT       ((tag_type_t)0x00C9) /* Unsigned 64–bit integer value */
-#define TAG_CIP_TYPE_REAL        ((tag_type_t)0x00CA) /* 32–bit floating point value, IEEE format */
-#define TAG_CIP_TYPE_LREAL       ((tag_type_t)0x00CB) /* 64–bit floating point value, IEEE format */
+#define TAG_CIP_TYPE_SINT        ((tag_type_t)0x00C2) /* Signed 8-bit integer value */
+#define TAG_CIP_TYPE_INT         ((tag_type_t)0x00C3) /* Signed 16-bit integer value */
+#define TAG_CIP_TYPE_DINT        ((tag_type_t)0x00C4) /* Signed 32-bit integer value */
+#define TAG_CIP_TYPE_LINT        ((tag_type_t)0x00C5) /* Signed 64-bit integer value */
+#define TAG_CIP_TYPE_USINT       ((tag_type_t)0x00C6) /* Unsigned 8-bit integer value */
+#define TAG_CIP_TYPE_UINT        ((tag_type_t)0x00C7) /* Unsigned 16-bit integer value */
+#define TAG_CIP_TYPE_UDINT       ((tag_type_t)0x00C8) /* Unsigned 32-bit integer value */
+#define TAG_CIP_TYPE_ULINT       ((tag_type_t)0x00C9) /* Unsigned 64-bit integer value */
+#define TAG_CIP_TYPE_REAL        ((tag_type_t)0x00CA) /* 32-bit floating point value, IEEE format */
+#define TAG_CIP_TYPE_LREAL       ((tag_type_t)0x00CB) /* 64-bit floating point value, IEEE format */
 #define TAG_CIP_TYPE_STRING      ((tag_type_t)0x00D0) /* 88-byte string, with 82 bytes of data, 4-byte count and 2 bytes of padding */
 
 /* PCCC data types.   FIXME */
-#define TAG_PCCC_TYPE_INT         ((uint8_t)0x89) /* Signed 16–bit integer value */
-#define TAG_PCCC_TYPE_DINT        ((uint8_t)0x91) /* Signed 32–bit integer value */
-#define TAG_PCCC_TYPE_REAL        ((uint8_t)0x8a) /* 32–bit floating point value, IEEE format */
+#define TAG_PCCC_TYPE_INT         ((uint8_t)0x89) /* Signed 16-bit integer value */
+#define TAG_PCCC_TYPE_DINT        ((uint8_t)0x91) /* Signed 32-bit integer value */
+#define TAG_PCCC_TYPE_REAL        ((uint8_t)0x8a) /* 32-bit floating point value, IEEE format */
 #define TAG_PCCC_TYPE_STRING      ((uint8_t)0x8d) /* 82-byte string with 2-byte count word. */
 
 struct tag_def_s {


### PR DESCRIPTION
It seems be a special unicode line that looks like minus. Windows build with multibyte dislike it :-)