### PR TITLE
Fix 308 - Omron performance

### DIFF
--- a/src/protocols/ab/ab_common.c
+++ b/src/protocols/ab/ab_common.c
@@ -365,12 +365,6 @@ plc_tag_p ab_tag_create(attr attribs)
             tag->vtable = &eip_cip_vtable;
         }
 
-        /* if this was not filled in elsewhere default to Logix */
-        if(tag->vtable == &default_vtable || !tag->vtable) {
-            pdebug(DEBUG_DETAIL, "Setting default Logix vtable.");
-            tag->vtable = &eip_cip_vtable;
-        }
-
         /* default to requiring a connection. */
         tag->use_connected_msg = attr_get_int(attribs,"use_connected_msg", 1);
         tag->allow_packing = attr_get_int(attribs, "allow_packing", 1);
@@ -385,7 +379,6 @@ plc_tag_p ab_tag_create(attr attribs)
         }
 
         tag->byte_order = &logix_tag_byte_order;
-
         tag->use_connected_msg = 1;
         tag->allow_packing = 0;
         tag->vtable = &eip_cip_vtable;
@@ -400,10 +393,9 @@ plc_tag_p ab_tag_create(attr attribs)
             return (plc_tag_p)tag;
         }
 
-        tag->byte_order = &logix_tag_byte_order;
-
+        tag->byte_order = &omron_njnx_tag_byte_order;
         tag->use_connected_msg = 1;
-        tag->allow_packing = 0;
+        tag->allow_packing = 1;
         tag->vtable = &eip_cip_vtable;
         break;
 

--- a/src/protocols/ab/eip_cip.c
+++ b/src/protocols/ab/eip_cip.c
@@ -181,6 +181,29 @@ tag_byte_order_t logix_tag_byte_order = {
     .str_pad_bytes = 2
 };
 
+
+/* default string types used for Omron-NJ/NX PLCs. */
+tag_byte_order_t omron_njnx_tag_byte_order = {
+    .is_allocated = 0,
+
+    .int16_order = {0,1},
+    .int32_order = {0,1,2,3},
+    .int64_order = {0,1,2,3,4,5,6,7},
+    .float32_order = {0,1,2,3},
+    .float64_order = {0,1,2,3,4,5,6,7},
+
+    .str_is_defined = 1,
+    .str_is_counted = 1,
+    .str_is_fixed_length = 0,
+    .str_is_zero_terminated = 1,
+    .str_is_byte_swapped = 0,
+
+    .str_count_word_bytes = 2,
+    .str_max_capacity = 0,
+    .str_total_length = 0,
+    .str_pad_bytes = 0
+};
+
 tag_byte_order_t logix_tag_listing_byte_order = {
     .is_allocated = 0,
 

--- a/src/protocols/ab/eip_cip.h
+++ b/src/protocols/ab/eip_cip.h
@@ -38,6 +38,7 @@
 
 extern struct tag_vtable_t eip_cip_vtable;
 extern tag_byte_order_t logix_tag_byte_order;
+extern tag_byte_order_t omron_njnx_tag_byte_order;
 extern tag_byte_order_t logix_tag_listing_byte_order;
 
 /* tag listing helpers */

--- a/src/tests/run_tests.sh
+++ b/src/tests/run_tests.sh
@@ -60,7 +60,7 @@ fi
 
 echo "Doing tests that need the local emulator."
 
-echo -n "Starting AB emulator... "
+echo -n "Starting AB emulator for ControlLogix tests... "
 $TEST_DIR/ab_server --plc=ControlLogix --path=1,0 --tag=TestBigArray:DINT[2000] --delay=5  > ab_emulator.log 2>&1 &
 EMULATOR_PID=$!
 if [ $? != 0 ]; then
@@ -85,6 +85,34 @@ fi
 
 echo "Killing AB emulator."
 killall -TERM ab_server
+
+
+echo -n "Starting AB emulator for Omron tests... "
+$TEST_DIR/ab_server --debug --plc=Omron --tag=TestDINTArray:DINT[10] > omron_emulator.log 2>&1 &
+EMULATOR_PID=$!
+if [ $? != 0 ]; then
+    echo "FAILURE"
+    echo "Unable to start AB emulator."
+    exit 1
+else
+    echo "OK"
+fi
+
+
+echo -n "Test basic Omron read/write... "
+$TEST_DIR/./tag_rw2 --type=sint32  '--tag=protocol=ab-eip&gateway=127.0.0.1&path=18,127.0.0.1&plc=omron-njnx&name=TestDINTArray' --write=42 --debug=4 > omron_tag_test.log 2>&1
+if [ $? != 0 ]; then
+    echo "FAILURE"
+    let FAILURES++
+else
+    echo "OK"
+    let SUCCESSES++
+fi
+
+
+echo "Killing Omron emulator."
+killall -TERM ab_server
+
 
 
 echo -n "Starting Modbus emulator... "


### PR DESCRIPTION
This adds support for larger packet sizes (1996 bytes) and multi-request packets.  It splits out strings on Omron and has a best guess at how they differ from ControlLogix strings.