### PR TITLE
Omron fixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -86,7 +86,7 @@ if(${CROSS_BUILD_TYPE} MATCHES "Linux-Arm6")
     set(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM NEVER)
 
     message("Building for Linux (Ubuntu/Debian) Arm v6")
-    elseif(${CROSS_BUILD_TYPE} MATCHES "Linux-Arm7")
+elseif(${CROSS_BUILD_TYPE} MATCHES "Linux-Arm7")
     # this also announces that we are cross compiling
     set(CMAKE_SYSTEM_NAME Linux)
 

--- a/src/protocols/ab/session.c
+++ b/src/protocols/ab/session.c
@@ -511,15 +511,18 @@ ab_session_p session_create_unsafe(const char *host, const char *path, plc_type_
     switch(plc_type) {
     case AB_PLC_SLC:
         session->max_payload_size = MAX_CIP_SLC_MSG_SIZE;
+        session->only_use_old_forward_open = 1;
         break;
 
     case AB_PLC_MLGX:
         session->max_payload_size = MAX_CIP_MLGX_MSG_SIZE;
+        session->only_use_old_forward_open = 1;
         break;
 
     case AB_PLC_PLC5:
     case AB_PLC_LGX_PCCC:
         session->max_payload_size = MAX_CIP_PLC5_MSG_SIZE;
+        session->only_use_old_forward_open = 1;
         break;
 
     case AB_PLC_LGX:

--- a/src/tests/run_tests.sh
+++ b/src/tests/run_tests.sh
@@ -36,6 +36,39 @@ else
     let SUCCESSES++
 fi
 
+
+echo -n "Test Micrologix... "
+$TEST_DIR/tag_rw2 --type=uint8 '--tag=protocol=ab-eip&gateway=10.206.1.36&plc=micrologix&elem_count=1&elem_size=2&name=N7:0/14' --write=0 --debug=4 > micrologix.log 2>&1
+if [ $? != 0 ]; then
+    echo "FAILURE"
+    let FAILURES++
+else
+    echo "OK"
+    let SUCCESSES++
+fi
+
+echo -n "Test PLC-5... "
+$TEST_DIR/tag_rw2 --type=uint8 '--tag=protocol=ab-eip&gateway=10.206.1.38&plc=plc5&elem_count=1&elem_size=2&name=B3:0/10' --debug=4 --write=0 > plc5.log 2>&1
+if [ $? != 0 ]; then
+    echo "FAILURE"
+    let FAILURES++
+else
+    echo "OK"
+    let SUCCESSES++
+fi
+
+
+echo -n "Test DH+ bridging... "
+$TEST_DIR/tag_rw2 --type=uint8 '--tag=protocol=ab_eip&gateway=10.206.1.40&path=1,2,A:27:1&cpu=plc5&elem_count=1&elem_size=2&name=B3:0/10' --debug=4 --write=0  > dhp_bridge.log 2>&1
+if [ $? != 0 ]; then
+    echo "FAILURE"
+    let FAILURES++
+else
+    echo "OK"
+    let SUCCESSES++
+fi
+
+
 echo -n "Test tag listing... "
 $TEST_DIR/list_tags "10.206.1.40" "1,4" > list_tags_test.log 2>&1
 if [ $? != 0 ]; then


### PR DESCRIPTION
Suppress request packing because Omron does not support partial responses so the client must do all the checks to see if the requests can be sent.   Suppress tag listing and UDT listing as Omron must do these slightly differently than Rockwell.