### PR TITLE
VS 2022 does not define WIN32 and only defines _WIN32.  

### DIFF
--- a/src/examples/async_stress.c
+++ b/src/examples/async_stress.c
@@ -44,7 +44,7 @@
 #include <string.h>
 #include <stdlib.h>
 #include <inttypes.h>
-#ifdef WIN32
+#if defined(WIN32) || defined(_WIN32)
     #include <Windows.h>
 #else
     #include <signal.h>

--- a/src/examples/multithread.c
+++ b/src/examples/multithread.c
@@ -34,7 +34,7 @@
 #include <stdio.h>
 #include <string.h>
 #include <stdlib.h>
-#ifdef WIN32
+#if defined(WIN32) || defined(_WIN32)
 #include <Windows.h>
 #else
 #include <pthread.h>
@@ -62,7 +62,7 @@
 
 
 
-#ifdef _WIN32
+#if defined(WIN32) || defined(_WIN32)
 volatile int done = 0;
 
 /* straight from MS' web site :-) */
@@ -143,7 +143,7 @@ volatile int32_t tag;
  * Thread function.  Just read until killed.
  */
 
-#ifdef WIN32
+#if defined(WIN32) || defined(_WIN32)
 DWORD __stdcall thread_func(LPVOID data)
 #else
 void *thread_func(void *data)
@@ -202,7 +202,7 @@ void *thread_func(void *data)
         util_sleep_ms(1);
     }
 
-#ifdef WIN32
+#if defined(WIN32) || defined(_WIN32)
     return (DWORD)0;
 #else
     return NULL;
@@ -213,7 +213,7 @@ void *thread_func(void *data)
 int main(int argc, char **argv)
 {
     int rc = PLCTAG_STATUS_OK;
-#ifdef WIN32
+#if defined(WIN32) || defined(_WIN32)
     HANDLE thread[MAX_THREADS];
 #else
     pthread_t thread[MAX_THREADS];
@@ -265,7 +265,7 @@ int main(int argc, char **argv)
     fprintf(stderr,"Creating %d threads.\n",num_threads);
 
     for(thread_id=0; thread_id < num_threads; thread_id++) {
-#ifdef WIN32
+#if defined(WIN32) || defined(_WIN32)
         thread[thread_id] = CreateThread(
                                         NULL,                       /* default security attributes */
                                         0,                          /* use default stack size      */
@@ -284,7 +284,7 @@ int main(int argc, char **argv)
     }
 
     for(thread_id = 0; thread_id < num_threads; thread_id++) {
-#ifdef WIN32
+#if defined(WIN32) || defined(_WIN32)
         WaitForSingleObject(thread[thread_id], (DWORD)INFINITE);
 #else
         pthread_join(thread[thread_id], NULL);

--- a/src/examples/test_connection_group.c
+++ b/src/examples/test_connection_group.c
@@ -43,7 +43,7 @@
 #include <string.h>
 #include <stdlib.h>
 #include <inttypes.h>
-#ifdef WIN32
+#if defined(WIN32) || defined(_WIN32)
 #include <Windows.h>
 #else
 #include <pthread.h>
@@ -172,7 +172,7 @@ typedef struct {
 
 
 
-#ifdef WIN32
+#if defined(WIN32) || defined(_WIN32)
 DWORD __stdcall test_runner(LPVOID data)
 #else
 void* test_runner(void* data)
@@ -231,7 +231,7 @@ void* test_runner(void* data)
 
     fflush(stderr);
 
-#ifdef WIN32
+#if defined(WIN32) || defined(_WIN32)
     return (DWORD)0;
 #else
     return NULL;
@@ -243,7 +243,7 @@ void* test_runner(void* data)
 
 int main(int argc, char **argv)
 {
-#ifdef WIN32
+#if defined(WIN32) || defined(_WIN32)
     HANDLE thread[MAX_THREADS];
 #else
     pthread_t thread[MAX_THREADS];
@@ -341,7 +341,7 @@ int main(int argc, char **argv)
     for(int tid=0; tid < num_threads  && tid < MAX_THREADS; tid++) {
         fprintf(stderr, "--- Creating test thread %d.\n", args[tid].tid);
 
-#ifdef WIN32
+#if defined(WIN32) || defined(_WIN32)
         thread[tid] = CreateThread( NULL,                       /* default security attributes */
                                     0,                          /* use default stack size      */
                                     test_runner,                /* thread function             */
@@ -376,7 +376,7 @@ int main(int argc, char **argv)
     util_sleep_ms(100);
 
     for(int tid=0; tid < num_threads && tid < MAX_THREADS; tid++) {
-#ifdef WIN32
+#if defined(WIN32) || defined(_WIN32)
         WaitForSingleObject(thread[tid], (DWORD)INFINITE);
 #else
         pthread_join(thread[tid], NULL);

--- a/src/examples/thread_stress.c
+++ b/src/examples/thread_stress.c
@@ -44,7 +44,7 @@
 #include <string.h>
 #include <stdlib.h>
 #include <inttypes.h>
-#ifdef WIN32
+#if defined(WIN32) || defined(_WIN32)
 #include <Windows.h>
 #else
 #include <pthread.h>
@@ -172,7 +172,7 @@ typedef struct {
 
 
 
-#ifdef WIN32
+#if defined(WIN32) || defined(_WIN32)
 DWORD __stdcall test_runner(LPVOID data)
 #else
 void* test_runner(void* data)
@@ -231,7 +231,7 @@ void* test_runner(void* data)
 
     fflush(stderr);
 
-#ifdef WIN32
+#if defined(WIN32) || defined(_WIN32)
     return (DWORD)0;
 #else
     return NULL;
@@ -243,7 +243,7 @@ void* test_runner(void* data)
 
 int main(int argc, char **argv)
 {
-#ifdef WIN32
+#if defined(WIN32) || defined(_WIN32)
     HANDLE thread[MAX_THREADS];
 #else
     pthread_t thread[MAX_THREADS];
@@ -316,7 +316,7 @@ int main(int argc, char **argv)
     for(int tid=0; tid < num_threads  && tid < MAX_THREADS; tid++) {
         fprintf(stderr, "--- Creating test thread %d.\n", args[tid].tid);
 
-#ifdef WIN32
+#if defined(WIN32) || defined(_WIN32)
         thread[tid] = CreateThread( NULL,                       /* default security attributes */
                                     0,                          /* use default stack size      */
                                     test_runner,                /* thread function             */
@@ -351,7 +351,7 @@ int main(int argc, char **argv)
     util_sleep_ms(100);
 
     for(int tid=0; tid < num_threads && tid < MAX_THREADS; tid++) {
-#ifdef WIN32
+#if defined(WIN32) || defined(_WIN32)
         WaitForSingleObject(thread[tid], (DWORD)INFINITE);
 #else
         pthread_join(thread[tid], NULL);


### PR DESCRIPTION
This commit fixes shared examples.