### PR TITLE
Fix event status

### DIFF
--- a/src/examples/test_callback.c
+++ b/src/examples/test_callback.c
@@ -1,5 +1,5 @@
 /***************************************************************************
- *   Copyright (C) 2020 by Kyle Hayes                                      *
+ *   Copyright (C) 2022 by Kyle Hayes                                      *
  *   Author Kyle Hayes  kyle.hayes@gmail.com                               *
  *                                                                         *
  * This software is available under either the Mozilla Public License      *
@@ -52,7 +52,7 @@ void tag_callback(int32_t tag_id, int event, int status)
     /* handle the events. */
     switch(event) {
     case PLCTAG_EVENT_ABORTED:
-        printf("Tag operation was aborted!\n");
+        printf("Tag operation was aborted with status %s!\n", plc_tag_decode_error(status));
         break;
 
     case PLCTAG_EVENT_CREATED:
@@ -64,7 +64,7 @@ void tag_callback(int32_t tag_id, int event, int status)
             free((void *)TestDINTArray);
             TestDINTArray = NULL;
         }
-        printf("Tag was destroyed.\n");
+        printf("Tag was destroyed with status %s.\n", plc_tag_decode_error(status));
         break;
 
     case PLCTAG_EVENT_READ_COMPLETED:
@@ -82,15 +82,11 @@ void tag_callback(int32_t tag_id, int event, int status)
         break;
 
     case PLCTAG_EVENT_READ_STARTED:
-        printf("Tag read operation started.\n");
+        printf("Tag read operation started with status %s.\n", plc_tag_decode_error(status));
         break;
 
     case PLCTAG_EVENT_WRITE_COMPLETED:
-        if(status == PLCTAG_STATUS_OK) {
-            printf("Tag write operation completed.\n");
-        } else {
-            printf("Tag write operation failed with status %s!\n", plc_tag_decode_error(status));
-        }
+        printf("Tag write operation completed with status %s!\n", plc_tag_decode_error(status));
         break;
 
     case PLCTAG_EVENT_WRITE_STARTED:

--- a/src/examples/test_callback_ex.c
+++ b/src/examples/test_callback_ex.c
@@ -1,5 +1,5 @@
 /***************************************************************************
- *   Copyright (C) 2020 by Kyle Hayes                                      *
+ *   Copyright (C) 2022 by Kyle Hayes                                      *
  *   Author Kyle Hayes  kyle.hayes@gmail.com                               *
  *                                                                         *
  * This software is available under either the Mozilla Public License      *
@@ -37,7 +37,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 
-#define REQUIRED_VERSION 2, 1, 4
+#define REQUIRED_VERSION 2, 5, 0
 
 #define TAG_PATH "protocol=ab-eip&gateway=127.0.0.1&path=1,0&cpu=LGX&elem_count=10&name=TestBigArray"
 #define DATA_TIMEOUT 5000
@@ -60,7 +60,7 @@ void tag_callback(int32_t tag_id, int event, int status, void *userdata)
     /* handle the events. */
     switch(event) {
     case PLCTAG_EVENT_ABORTED:
-        printf("Tag operation was aborted!\n");
+        printf("Tag operation was aborted with status %s!\n", plc_tag_decode_error(status));
         break;
 
     case PLCTAG_EVENT_CREATED:
@@ -72,8 +72,7 @@ void tag_callback(int32_t tag_id, int event, int status, void *userdata)
             free((void *)TestDINTArray);
             TestDINTArray = NULL;
         }
-
-        printf("Tag was destroyed.\n");
+        printf("Tag was destroyed with status %s.\n", plc_tag_decode_error(status));
         break;
 
     case PLCTAG_EVENT_READ_COMPLETED:
@@ -91,15 +90,11 @@ void tag_callback(int32_t tag_id, int event, int status, void *userdata)
         break;
 
     case PLCTAG_EVENT_READ_STARTED:
-        printf("Tag read operation started.\n");
+        printf("Tag read operation started with status %s.\n", plc_tag_decode_error(status));
         break;
 
     case PLCTAG_EVENT_WRITE_COMPLETED:
-        if(status == PLCTAG_STATUS_OK) {
-            printf("Tag write operation completed.\n");
-        } else {
-            printf("Tag write operation failed with status %s!\n", plc_tag_decode_error(status));
-        }
+        printf("Tag write operation completed with status %s!\n", plc_tag_decode_error(status));
         break;
 
     case PLCTAG_EVENT_WRITE_STARTED:

--- a/src/lib/lib.c
+++ b/src/lib/lib.c
@@ -291,7 +291,8 @@ void plc_tag_generic_tickler(plc_tag_p tag)
                     tag->read_in_flight = 0;
 
                     /* TODO - should we report an ABORT event here? */
-                    tag->event_operation_aborted = 1;
+                    //tag->event_operation_aborted = 1;
+                    tag_raise_event(tag, PLCTAG_EVENT_ABORTED, PLCTAG_ERR_ABORT);
                 }
 
                 /* have we already done something about automatic reads? */
@@ -317,7 +318,8 @@ void plc_tag_generic_tickler(plc_tag_p tag)
                         tag->status = (int8_t)tag->vtable->write(tag);
                     }
 
-                    tag->event_write_started = 1;
+                    // tag->event_write_started = 1;
+                    tag_raise_event(tag, PLCTAG_EVENT_WRITE_STARTED, tag->status);
                 }
             }
         }
@@ -345,7 +347,8 @@ void plc_tag_generic_tickler(plc_tag_p tag)
                         tag->status = (int8_t)tag->vtable->read(tag);
                     }
 
-                    tag->event_read_started = 1;
+                    // tag->event_read_started = 1;
+                    tag_raise_event(tag, PLCTAG_EVENT_READ_STARTED, tag->status);
 
                     /*
                     * schedule the next read.
@@ -388,64 +391,64 @@ void plc_tag_generic_handle_event_callbacks(plc_tag_p tag)
     /* call the callbacks outside the API mutex. */
     if(tag && tag->callback) {
         int has_event =  tag->event_read_started || tag->event_read_complete
-                      || tag->event_write_started || tag->event_write_complete;
+                      || tag->event_write_started || tag->event_write_complete
+                      || tag->event_operation_aborted;
 
         debug_set_tag_id(tag->tag_id);
 
         /* synthesize create event if missing. */
         if(has_event && !tag->had_created_event) {
             tag->event_creation_complete = 1;
+            tag->event_creation_complete_status = plc_tag_status(tag->tag_id);
             tag->had_created_event = 1;
         }
 
         /* trigger this if there is any other event. Only once. */
         if(tag->event_creation_complete) {
             pdebug(DEBUG_DETAIL, "Tag creation complete.");
-            tag->callback(tag->tag_id, PLCTAG_EVENT_CREATED, plc_tag_status(tag->tag_id), tag->userdata);
+            tag->callback(tag->tag_id, PLCTAG_EVENT_CREATED, tag->event_creation_complete_status, tag->userdata);
             tag->event_creation_complete = 0;
+            tag->event_creation_complete_status = PLCTAG_STATUS_OK;
         }
 
         /* was there a read start? */
         if(tag->event_read_started) {
             pdebug(DEBUG_DETAIL, "Tag read started.");
-            tag->callback(tag->tag_id, PLCTAG_EVENT_READ_STARTED, plc_tag_status(tag->tag_id), tag->userdata);
+            tag->callback(tag->tag_id, PLCTAG_EVENT_READ_STARTED, tag->event_read_started_status, tag->userdata);
             tag->event_read_started = 0;
+            tag->event_read_started_status = PLCTAG_STATUS_OK;
         }
 
         /* was there a write start? */
         if(tag->event_write_started) {
             pdebug(DEBUG_DETAIL, "Tag write started.");
-            tag->callback(tag->tag_id, PLCTAG_EVENT_WRITE_STARTED, plc_tag_status(tag->tag_id), tag->userdata);
+            tag->callback(tag->tag_id, PLCTAG_EVENT_WRITE_STARTED, tag->event_write_started_status, tag->userdata);
             tag->event_write_started = 0;
+            tag->event_write_started_status = PLCTAG_STATUS_OK;
         }
 
         /* was there an abort? */
         if(tag->event_operation_aborted) {
             pdebug(DEBUG_DETAIL, "Tag operation aborted.");
-            tag->callback(tag->tag_id, PLCTAG_EVENT_ABORTED, plc_tag_status(tag->tag_id), tag->userdata);
+            tag->callback(tag->tag_id, PLCTAG_EVENT_ABORTED, tag->event_operation_aborted_status, tag->userdata);
             tag->event_operation_aborted = 0;
+            tag->event_operation_aborted_status = PLCTAG_STATUS_OK;
         }
 
         /* was there a read completion? */
         if(tag->event_read_complete) {
             pdebug(DEBUG_DETAIL, "Tag read completed.");
-            tag->callback(tag->tag_id, PLCTAG_EVENT_READ_COMPLETED, plc_tag_status(tag->tag_id), tag->userdata);
+            tag->callback(tag->tag_id, PLCTAG_EVENT_READ_COMPLETED, tag->event_read_complete_status, tag->userdata);
             tag->event_read_complete = 0;
+            tag->event_read_complete_status = PLCTAG_STATUS_OK;
         }
 
         /* was there a write completion? */
         if(tag->event_write_complete) {
             pdebug(DEBUG_DETAIL, "Tag write completed.");
-            tag->callback(tag->tag_id, PLCTAG_EVENT_WRITE_COMPLETED, plc_tag_status(tag->tag_id), tag->userdata);
+            tag->callback(tag->tag_id, PLCTAG_EVENT_WRITE_COMPLETED, tag->event_write_complete_status, tag->userdata);
             tag->event_write_complete = 0;
-        }
-
-        /* was there a write completion? */
-        if(tag->event_creation_complete) {
-            pdebug(DEBUG_DETAIL, "Tag creation completed.");
-            /* TODO - when API changes, add this. */
-            //tag->callback(tag->tag_id, PLCTAG_EVENT_CREATE_COMPLETE, plc_tag_status(tag->tag_id), tag->userdata);
-            tag->event_creation_complete = 0;
+            tag->event_write_complete_status = PLCTAG_STATUS_OK;
         }
 
         debug_set_tag_id(0);
@@ -553,7 +556,8 @@ THREAD_FUNC(tag_tickler_func)
                                 tag->read_complete = 0;
                                 tag->read_in_flight = 0;
 
-                                tag->event_read_complete = 1;
+                                //tag->event_read_complete = 1;
+                                tag_raise_event(tag, PLCTAG_EVENT_READ_COMPLETED, tag->status);
 
                                 /* wake immediately */
                                 plc_tag_tickler_wake();
@@ -565,7 +569,8 @@ THREAD_FUNC(tag_tickler_func)
                                 tag->write_in_flight = 0;
                                 tag->auto_sync_next_write = 0;
 
-                                tag->event_write_complete = 1;
+                                // tag->event_write_complete = 1;
+                                tag_raise_event(tag, PLCTAG_EVENT_WRITE_COMPLETED, tag->status);
 
                                 /* wake immediately */
                                 plc_tag_tickler_wake();
@@ -802,8 +807,6 @@ LIB_EXPORT int plc_tag_check_lib_version(int req_major, int req_minor, int req_p
 /*
  * plc_tag_create()
  *
- * Just pass through to the plc_tag_create_sync() function.
- *
  * This is where the dispatch occurs to the protocol specific implementation.
  */
 
@@ -1034,6 +1037,8 @@ LIB_EXPORT int32_t plc_tag_create(const char *attrib_str, int timeout)
                 return rc;
             }
         } while(rc == PLCTAG_STATUS_PENDING && time_ms() > end_time);
+
+        tag_raise_event(tag, PLCTAG_EVENT_CREATED, rc);
 
         /* clear up any remaining flags.  This should be refactored. */
         tag->read_in_flight = 0;

--- a/src/lib/tag.h
+++ b/src/lib/tag.h
@@ -122,6 +122,12 @@ typedef void (*tag_extended_callback_func)(int32_t tag_id, int event, int status
                         uint8_t event_read_complete: 1; \
                         uint8_t event_write_started: 1; \
                         uint8_t event_write_complete: 1; \
+                        int8_t event_creation_complete_status; \
+                        int8_t event_operation_aborted_status; \
+                        int8_t event_read_started_status; \
+                        int8_t event_read_complete_status; \
+                        int8_t event_write_started_status; \
+                        int8_t event_write_complete_status; \
                         int8_t status; \
                         int bit; \
                         int connection_group_id; \
@@ -163,3 +169,69 @@ extern int plc_tag_tickler_wake_impl(const char *func, int line_num);
 #define plc_tag_generic_wake_tag(tag) plc_tag_generic_wake_tag_impl(__func__, __LINE__, tag)
 extern int plc_tag_generic_wake_tag_impl(const char *func, int line_num, plc_tag_p tag);
 extern int plc_tag_generic_init_tag(plc_tag_p tag, attr attributes);
+
+static inline void tag_raise_event(plc_tag_p tag, int event, int8_t status) 
+{
+    switch(event) {
+        case PLCTAG_EVENT_ABORTED:
+            tag->event_operation_aborted = 1;
+            tag->event_operation_aborted_status = status;
+            if(!tag->had_created_event) {
+                tag->had_created_event = 1;
+                tag->event_creation_complete = 1;
+                tag->event_creation_complete_status = status;
+            }
+            break;
+
+        case PLCTAG_EVENT_CREATED:
+            tag->event_creation_complete = 1;
+            tag->event_creation_complete_status = status;
+            tag->had_created_event = 1;
+            break;
+
+        case PLCTAG_EVENT_READ_COMPLETED:
+            tag->event_read_complete = 1;
+            tag->event_read_complete_status = status;
+            if(!tag->had_created_event) {
+                tag->had_created_event = 1;
+                tag->event_creation_complete = 1;
+                tag->event_creation_complete_status = status;
+            }
+            break;
+
+        case PLCTAG_EVENT_READ_STARTED:
+            tag->event_read_started = 1;
+            tag->event_read_started_status = status;
+            if(!tag->had_created_event) {
+                tag->had_created_event = 1;
+                tag->event_creation_complete = 1;
+                tag->event_creation_complete_status = status;
+            }
+            break;
+
+        case PLCTAG_EVENT_WRITE_COMPLETED:
+            tag->event_write_complete = 1;
+            tag->event_write_complete_status = status;
+            if(!tag->had_created_event) {
+                tag->had_created_event = 1;
+                tag->event_creation_complete = 1;
+                tag->event_creation_complete_status = status;
+            }
+            break;
+
+        case PLCTAG_EVENT_WRITE_STARTED:
+            tag->event_write_started = 1;
+            tag->event_write_started_status = status;
+            if(!tag->had_created_event) {
+                tag->had_created_event = 1;
+                tag->event_creation_complete = 1;
+                tag->event_creation_complete_status = status;
+            }
+            break;
+
+        default:
+            pdebug(DEBUG_WARN, "Unsupported event %d!");
+            break;
+    }
+}
+


### PR DESCRIPTION
Attempt to clean up event status.   Still looks like there might be event duplication.   Also looks like there will be some multi-threaded race conditions on event clean up.   Should be harmless (i.e. won't crash anything) but it is not clear if the results will be accurate.