### PR TITLE
fix #369, CI build problem, fix #367, fix #365, buffer overrun fixes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -382,7 +382,7 @@ jobs:
       run: mkdir ${{ env.BUILD }}
 
     - name: Configure CMake
-      run: cd ${{ env.BUILD }}; cmake .. -G "Visual Studio 16 2019" -A x64
+      run: cd ${{ env.BUILD }}; cmake .. -G "Visual Studio 17 2022" -A x64
 
     - name: Build
       run: cd ${{ env.BUILD }}; cmake --build . --config Release
@@ -497,7 +497,7 @@ jobs:
       run: mkdir ${{ env.BUILD }}
 
     - name: Configure CMake
-      run: cd ${{ env.BUILD }}; cmake .. -G "Visual Studio 16 2019" -A Win32
+      run: cd ${{ env.BUILD }}; cmake .. -G "Visual Studio 17 2022" -A Win32
 
     - name: Build
       run: cd ${{ env.BUILD }}; cmake --build . --config Release
@@ -612,7 +612,7 @@ jobs:
       run: mkdir ${{ env.BUILD }}
 
     - name: Configure CMake
-      run: cd ${{ env.BUILD }}; cmake .. -G "Visual Studio 16 2019" -A ARM
+      run: cd ${{ env.BUILD }}; cmake .. -G "Visual Studio 17 2022" -A ARM
 
     - name: Build
       run: cd ${{ env.BUILD }}; cmake --build . --config Release
@@ -641,7 +641,7 @@ jobs:
       run: mkdir ${{ env.BUILD }}
 
     - name: Configure CMake
-      run: cd ${{ env.BUILD }}; cmake .. -G "Visual Studio 16 2019" -A ARM64
+      run: cd ${{ env.BUILD }}; cmake .. -G "Visual Studio 17 2022" -A ARM64
 
     - name: Build
       run: cd ${{ env.BUILD }}; cmake --build . --config Release

--- a/.github/workflows/ci.yml.in
+++ b/.github/workflows/ci.yml.in
@@ -382,7 +382,7 @@ jobs:
       run: mkdir ${{ env.BUILD }}
 
     - name: Configure CMake
-      run: cd ${{ env.BUILD }}; cmake .. -G "Visual Studio 16 2019" -A x64
+      run: cd ${{ env.BUILD }}; cmake .. -G "Visual Studio 17 2022" -A x64
 
     - name: Build
       run: cd ${{ env.BUILD }}; cmake --build . --config Release
@@ -497,7 +497,7 @@ jobs:
       run: mkdir ${{ env.BUILD }}
 
     - name: Configure CMake
-      run: cd ${{ env.BUILD }}; cmake .. -G "Visual Studio 16 2019" -A Win32
+      run: cd ${{ env.BUILD }}; cmake .. -G "Visual Studio 17 2022" -A Win32
 
     - name: Build
       run: cd ${{ env.BUILD }}; cmake --build . --config Release
@@ -612,7 +612,7 @@ jobs:
       run: mkdir ${{ env.BUILD }}
 
     - name: Configure CMake
-      run: cd ${{ env.BUILD }}; cmake .. -G "Visual Studio 16 2019" -A ARM
+      run: cd ${{ env.BUILD }}; cmake .. -G "Visual Studio 17 2022" -A ARM
 
     - name: Build
       run: cd ${{ env.BUILD }}; cmake --build . --config Release
@@ -641,7 +641,7 @@ jobs:
       run: mkdir ${{ env.BUILD }}
 
     - name: Configure CMake
-      run: cd ${{ env.BUILD }}; cmake .. -G "Visual Studio 16 2019" -A ARM64
+      run: cd ${{ env.BUILD }}; cmake .. -G "Visual Studio 17 2022" -A ARM64
 
     - name: Build
       run: cd ${{ env.BUILD }}; cmake --build . --config Release

--- a/src/protocols/ab/cip.c
+++ b/src/protocols/ab/cip.c
@@ -651,7 +651,7 @@ int parse_symbolic_segment(ab_tag_p tag, const char *name, int *encoded_index, i
     name_i++;
 
     /* get the rest of the name. */
-    while(isalnum(name[name_i]) || name[name_i] == ':' || name[name_i] == '_') {
+    while((isalnum(name[name_i]) || name[name_i] == ':' || name[name_i] == '_') && (encoded_i < (MAX_TAG_NAME - 1))) {
         tag->encoded_name[encoded_i] = (uint8_t)name[name_i];
         encoded_i++;
         tag->encoded_name[seg_len_index]++;
@@ -661,7 +661,7 @@ int parse_symbolic_segment(ab_tag_p tag, const char *name, int *encoded_index, i
     seg_len = tag->encoded_name[seg_len_index];
 
     /* finish up the encoded name.   Space for the name must be a multiple of two bytes long. */
-    if(tag->encoded_name[seg_len_index] & 0x01) {
+    if((tag->encoded_name[seg_len_index] & 0x01) && (encoded_i < MAX_TAG_NAME)) {
         tag->encoded_name[encoded_i] = 0;
         encoded_i++;
     }

--- a/src/protocols/mb/modbus.c
+++ b/src/protocols/mb/modbus.c
@@ -324,6 +324,11 @@ int create_tag_object(attr attribs, modbus_tag_p *tag)
     modbus_reg_type_t reg_type = MB_REG_UNKNOWN;
     int reg_base = 0;
 
+    if (elem_count < 0) {
+        pdebug(DEBUG_WARN, "Element count should not be a negative value!");
+        return PLCTAG_ERR_BAD_PARAM;
+    }
+
     pdebug(DEBUG_INFO, "Starting.");
 
     *tag = NULL;


### PR DESCRIPTION
Thanks to @tinajohnson for the buffer overrun fixes!   This also exposed a CI build problem on GitHub because Visual Studio version 16 is no longer available on the Windows CI runner pool.