### PR TITLE
Fix 393

### DIFF
--- a/src/examples/plc5.c
+++ b/src/examples/plc5.c
@@ -49,6 +49,7 @@ int main(int argc, char **argv)
 {
     int32_t tag = 0;
     int rc;
+    int file_type = 0;
     int i;
 
     (void)argc;
@@ -127,6 +128,10 @@ int main(int argc, char **argv)
     for(i=0; i < ELEM_COUNT; i++) {
         fprintf(stderr,"data[%d]=%f\n",i,plc_tag_get_float32(tag,(i*ELEM_SIZE)));
     }
+
+    /* see what the data type is */
+    file_type = plc_tag_get_int_attribute(tag, "elem_type", -1);
+    fprintf(stderr, "Reported data file type is 0x%02x.\n", file_type);
 
     /* we are done */
     plc_tag_destroy(tag);

--- a/src/protocols/ab/ab_common.c
+++ b/src/protocols/ab/ab_common.c
@@ -545,6 +545,7 @@ int get_tag_data_type(ab_tag_p tag, attr attribs)
         }
 
         tag->elem_size = file_addr.element_size_bytes;
+        tag->file_type = (int)file_addr.file_type;
 
         break;
 
@@ -866,6 +867,23 @@ int ab_get_int_attrib(plc_tag_p raw_tag, const char *attrib_name, int default_va
         res = tag->elem_size;
     } else if(str_cmp_i(attrib_name, "elem_count") == 0) {
         res = tag->elem_count;
+    } else if(str_cmp_i(attrib_name, "elem_type") == 0) {
+        switch(tag->plc_type) {
+            case AB_PLC_PLC5: /* fall through */
+            case AB_PLC_MLGX: /* fall through */
+            case AB_PLC_SLC: /* fall through */
+            case AB_PLC_LGX_PCCC:
+                res = (int)(tag->file_type);
+                break;
+            case AB_PLC_LGX: /* fall through */
+            case AB_PLC_MICRO800: /* fall through */
+            case AB_PLC_OMRON_NJNX:
+                res = (int)(tag->elem_type);
+                break;
+            default: 
+                pdebug(DEBUG_WARN, "Unsupported PLC type %d!", tag->plc_type);
+                break;
+        }
     } else {
         pdebug(DEBUG_WARN, "Unsupported attribute name \"%s\"!", attrib_name);
         tag->status = PLCTAG_ERR_UNSUPPORTED;


### PR DESCRIPTION
Add back support for PCCC file types via the integer attribute elem_type.