### PR TITLE
google sanitizers can be turned off for debug builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -143,6 +143,8 @@ endif()
 # build examples flag
 set(BUILD_EXAMPLES 1 CACHE BOOL "Build examples or not")
 
+set(USE_SANITIZERS 1 CACHE BOOL "Build with google sanitizers or not")
+
 # set flags for MacOSX
 if (APPLE)
     set(CMAKE_MACOSX_RPATH ON)
@@ -258,11 +260,17 @@ elseif (CMAKE_C_COMPILER_ID STREQUAL "GNU")
         SET(STR_OP_OVERFLOW_OFF "")
     endif()
 
-    set(BASE_RELEASE_FLAGS "${CMAKE_C_FLAGS} -Wall -pedantic -Wextra -Wconversion -fms-extensions -fno-strict-aliasing -fvisibility=hidden ${STR_OP_OVERFLOW_OFF} -D__USE_POSIX=1 -D_POSIX_C_SOURCE=200809L")
-    set(BASE_DEBUG_FLAGS "${CMAKE_C_FLAGS} -g -Wall -pedantic -Wextra -Wconversion -fms-extensions -fno-strict-aliasing -fvisibility=hidden -fsanitize=address -fsanitize=leak -fsanitize=undefined ${STR_OP_OVERFLOW_ON} -D__USE_POSIX=1 -D_POSIX_C_SOURCE=200809L")
-	set(C99_FLAGS "-std=c99" )
-    set(BASE_RELEASE_LINK_FLAGS "")
-    set(BASE_DEBUG_LINK_FLAGS "-fsanitize=address -fsanitize=leak -fsanitize=undefined")
+    SET(BASE_RELEASE_FLAGS "${CMAKE_C_FLAGS} -Wall -pedantic -Wextra -Wconversion -fms-extensions -fno-strict-aliasing -fvisibility=hidden ${STR_OP_OVERFLOW_OFF} -D__USE_POSIX=1 -D_POSIX_C_SOURCE=200809L")
+    SET(BASE_DEBUG_FLAGS "${CMAKE_C_FLAGS} -g -Wall -pedantic -Wextra -Wconversion -fms-extensions -fno-strict-aliasing -fvisibility=hidden ${STR_OP_OVERFLOW_ON} -D__USE_POSIX=1 -D_POSIX_C_SOURCE=200809L")
+	SET(C99_FLAGS "-std=c99" )
+    SET(BASE_RELEASE_LINK_FLAGS "")
+    SET(BASE_DEBUG_LINK_FLAGS "")
+
+    if(USE_SANITIZERS)
+        SET(SANITIZERS_FLAGS " -fsanitize=address -fsanitize=leak -fsanitize=undefined")
+        STRING(APPEND BASE_DEBUG_FLAGS ${SANITIZERS_FLAGS})
+        STRING(APPEND BASE_DEBUG_LINK_FLAGS ${SANITIZERS_FLAGS})
+    endif()
 
     # check to see if we are building 32-bit or 64-bit
     if(BUILD_32_BIT)


### PR DESCRIPTION
The goal is to make sanitizers optional, so I introduced the `USE_SANITIZERS` cmake option that is `ON` by default to maintain the current behavior. 

closes #423 

To build with : 

```sh
cmake -DUSE_SANITIZERS=ON -DCMAKE_BUILD_TYPE=Debug  .

# will produce exec that link against `asan.so`

ldd ./bin_dist/simple
        linux-vdso.so.1 (0x00007ffd58d46000)
        libasan.so.6 => /lib/x86_64-linux-gnu/libasan.so.6 (0x00007f14b3800000)
        libplctag.so.2.5 => /home/tvincent/dev/libplctag/build/bin_dist/libplctag.so.2.5 (0x00007f14b3200000)
        libubsan.so.1 => /lib/x86_64-linux-gnu/libubsan.so.1 (0x00007f14b2a00000)
        libc.so.6 => /lib/x86_64-linux-gnu/libc.so.6 (0x00007f14b2600000)
        libm.so.6 => /lib/x86_64-linux-gnu/libm.so.6 (0x00007f14b4202000)
        libgcc_s.so.1 => /lib/x86_64-linux-gnu/libgcc_s.so.1 (0x00007f14b37e0000)
        libstdc++.so.6 => /lib/x86_64-linux-gnu/libstdc++.so.6 (0x00007f14b2200000)
        /lib64/ld-linux-x86-64.so.2 (0x00007f14b4307000)
```

to build without:

```sh
cmake -DUSE_SANITIZERS=OFF -DCMAKE_BUILD_TYPE=Debug  .

ldd ./bin_dist/simple                                   
        linux-vdso.so.1 (0x00007ffd843d8000)
        libplctag.so.2.5 => /home/tvincent/dev/libplctag/build/bin_dist/libplctag.so.2.5 (0x00007fcfc75bc000)
        libc.so.6 => /lib/x86_64-linux-gnu/libc.so.6 (0x00007fcfc7200000)
        /lib64/ld-linux-x86-64.so.2 (0x00007fcfc7629000)
```
