### PR TITLE
Changes for improved Omron NJ/NX compatibility

### DIFF
--- a/src/lib/lib.c
+++ b/src/lib/lib.c
@@ -3980,7 +3980,7 @@ int set_tag_byte_order(plc_tag_p tag, attr attribs)
         use_default = 0;
     }
 
-    if(attr_get_str(attribs, "str_pad_to_16_bits", NULL) != NULL) {
+    if(attr_get_str(attribs, "str_pad_to_multiple_bytes", NULL) != NULL) {
         use_default = 0;
     }
 
@@ -4189,14 +4189,15 @@ int set_tag_byte_order(plc_tag_p tag, attr attribs)
             }
         }
 
-        /* Should we pad the string to an even number of bytes. Doing this causes issues when writing OmronNJ strings, 
-            required for certain AB PLCs*/
-        if(attr_get_str(attribs, "str_pad_to_16_bits", NULL)) {
-            str_param = attr_get_int(attribs, "str_pad_to_16_bits", 0);
-            if(str_param == 0 || str_param == 1) {
-                tag->byte_order->str_pad_to_16_bits = (unsigned int)str_param;
+        /* Should we pad the string to a multiple of 1 (no padding), 2, or 4 bytes. Adding padding causes issues when writing OmronNJ strings, 
+            2 byte padding is required for certain AB PLCs*/
+        if(attr_get_str(attribs, "str_pad_to_multiple_bytes", NULL)) {
+            str_param = attr_get_int(attribs, "str_pad_to_multiple_bytes", 0);
+            if(str_param == 0 || str_param == 1 || str_param == 2 || str_param == 4) {
+                if (str_param == 0) {str_param=1;} /* Padding to 0 bytes doesnt make much sense, so we overwride to 1 byte which means no padding */
+                tag->byte_order->str_pad_to_multiple_bytes = (unsigned int)str_param;
             } else {
-                pdebug(DEBUG_WARN, "Tag string attribute str_pad_to_16_bits must be missing, 0, or 1!");
+                pdebug(DEBUG_WARN, "Tag string attribute str_pad_to_multiple_bytes must be missing, 1, 2 or 4!");
                 return PLCTAG_ERR_BAD_PARAM;
             }
         }

--- a/src/lib/lib.c
+++ b/src/lib/lib.c
@@ -3980,6 +3980,10 @@ int set_tag_byte_order(plc_tag_p tag, attr attribs)
         use_default = 0;
     }
 
+    if(attr_get_str(attribs, "str_pad_to_16_bits", NULL) != NULL) {
+        use_default = 0;
+    }
+
     /* if we need to override something, build a new byte order structure. */
     if(!use_default) {
         const char *byte_order_str = NULL;
@@ -4181,6 +4185,18 @@ int set_tag_byte_order(plc_tag_p tag, attr attribs)
                 tag->byte_order->str_pad_bytes = (unsigned int)str_param;
             } else {
                 pdebug(DEBUG_WARN, "Tag string attribute str_pad_bytes must be missing, 0, or positive!");
+                return PLCTAG_ERR_BAD_PARAM;
+            }
+        }
+
+        /* Should we pad the string to an even number of bytes. Doing this causes issues when writing OmronNJ strings, 
+            required for certain AB PLCs*/
+        if(attr_get_str(attribs, "str_pad_to_16_bits", NULL)) {
+            str_param = attr_get_int(attribs, "str_pad_to_16_bits", 0);
+            if(str_param == 0 || str_param == 1) {
+                tag->byte_order->str_pad_to_16_bits = (unsigned int)str_param;
+            } else {
+                pdebug(DEBUG_WARN, "Tag string attribute str_pad_to_16_bits must be missing, 0, or 1!");
                 return PLCTAG_ERR_BAD_PARAM;
             }
         }

--- a/src/lib/tag.h
+++ b/src/lib/tag.h
@@ -80,6 +80,7 @@ struct tag_byte_order_s {
     unsigned int str_is_fixed_length:1;
     unsigned int str_is_zero_terminated:1;
     unsigned int str_is_byte_swapped:1;
+    unsigned int str_pad_to_16_bits:1;
 
     unsigned int str_count_word_bytes;
     unsigned int str_max_capacity;

--- a/src/lib/tag.h
+++ b/src/lib/tag.h
@@ -80,8 +80,8 @@ struct tag_byte_order_s {
     unsigned int str_is_fixed_length:1;
     unsigned int str_is_zero_terminated:1;
     unsigned int str_is_byte_swapped:1;
-    unsigned int str_pad_to_16_bits:1;
 
+    unsigned int str_pad_to_multiple_bytes;
     unsigned int str_count_word_bytes;
     unsigned int str_max_capacity;
     unsigned int str_total_length;

--- a/src/protocols/ab/ab_common.c
+++ b/src/protocols/ab/ab_common.c
@@ -440,7 +440,6 @@ plc_tag_p ab_tag_create(attr attribs, void (*tag_callback_func)(int32_t tag_id, 
     tag->elem_count = attr_get_int(attribs,"elem_count", 1);
 
     switch(tag->plc_type) {
-        /* fall through */
     case AB_PLC_OMRON_NJNX:
         /* fall through */
     case AB_PLC_LGX:

--- a/src/protocols/ab/ab_common.c
+++ b/src/protocols/ab/ab_common.c
@@ -440,14 +440,8 @@ plc_tag_p ab_tag_create(attr attribs, void (*tag_callback_func)(int32_t tag_id, 
     tag->elem_count = attr_get_int(attribs,"elem_count", 1);
 
     switch(tag->plc_type) {
+        /* fall through */
     case AB_PLC_OMRON_NJNX:
-        if (tag->elem_count != 1) {
-            tag->elem_count = 1;
-            pdebug(DEBUG_WARN,"Attribute elem_count should be 1!");
-        }
-
-        /* from here is the same as a AB_PLC_MICRO800. */
-
         /* fall through */
     case AB_PLC_LGX:
     case AB_PLC_MICRO800:

--- a/src/protocols/ab/eip_cip.c
+++ b/src/protocols/ab/eip_cip.c
@@ -1245,9 +1245,14 @@ int build_write_request_unconnected(ab_tag_p tag, int byte_offset)
     tag->offset += write_size;
 
     /* need to pad data to multiple of 16-bits */
-    if (write_size & 0x01) {
-        *data = 0;
-        data++;
+    /* for some PLCs (OmronNJ), padding causes issues when writing counted strings as it creates a mismatch between
+        the length of the string and the count integer, therefor this padding can be disabled using the str_pad_16_bits attribute */
+    pad_to_even_bytes = tag->byte_order->str_pad_to_16_bits;
+    if (pad_to_even_bytes == 1){
+        if (write_size & 0x01) {
+            *data = 0;
+            data++;
+        }
     }
 
     /* now we go back and fill in the fields of the static part */

--- a/src/protocols/ab/eip_cip.c
+++ b/src/protocols/ab/eip_cip.c
@@ -1152,6 +1152,7 @@ int build_write_request_unconnected(ab_tag_p tag, int byte_offset)
     ab_request_p req = NULL;
     int multiple_requests = 0;
     int write_size = 0;
+    int pad_to_even_bytes = 1;
 
     pdebug(DEBUG_INFO, "Starting.");
 

--- a/src/protocols/ab/eip_plc5_pccc.c
+++ b/src/protocols/ab/eip_plc5_pccc.c
@@ -77,8 +77,8 @@ tag_byte_order_t plc5_tag_byte_order = {
     .str_is_fixed_length = 1,
     .str_is_zero_terminated = 0,
     .str_is_byte_swapped = 1,
-    .str_pad_to_16_bits = 1,
 
+    .str_pad_to_multiple_bytes = 2,
     .str_count_word_bytes = 2,
     .str_max_capacity = 82,
     .str_total_length = 84,

--- a/src/protocols/ab/eip_plc5_pccc.c
+++ b/src/protocols/ab/eip_plc5_pccc.c
@@ -77,6 +77,7 @@ tag_byte_order_t plc5_tag_byte_order = {
     .str_is_fixed_length = 1,
     .str_is_zero_terminated = 0,
     .str_is_byte_swapped = 1,
+    .str_pad_to_16_bits = 1,
 
     .str_count_word_bytes = 2,
     .str_max_capacity = 82,

--- a/src/protocols/ab/eip_slc_pccc.c
+++ b/src/protocols/ab/eip_slc_pccc.c
@@ -76,6 +76,7 @@ tag_byte_order_t slc_tag_byte_order = {
     .str_is_fixed_length = 1,
     .str_is_zero_terminated = 0,
     .str_is_byte_swapped = 1,
+    .str_pad_to_16_bits = 1,
 
     .str_count_word_bytes = 2,
     .str_max_capacity = 82,

--- a/src/protocols/ab/eip_slc_pccc.c
+++ b/src/protocols/ab/eip_slc_pccc.c
@@ -76,8 +76,8 @@ tag_byte_order_t slc_tag_byte_order = {
     .str_is_fixed_length = 1,
     .str_is_zero_terminated = 0,
     .str_is_byte_swapped = 1,
-    .str_pad_to_16_bits = 1,
-
+    
+    .str_pad_to_multiple_bytes = 2,
     .str_count_word_bytes = 2,
     .str_max_capacity = 82,
     .str_total_length = 84,


### PR DESCRIPTION
This pull request relates to issues #430, #431 and possibly #451. The two primary things which this PR addresses are the hard limit on only being able to write a 1 single element to an array at once, and forced padding to an even number of bytes when writing strings. 

With regards to writing to multiple elements, I have been writing to multiple elements of an array on an Omron NJ with no problems. Only if you try and write to so many elements that you exceed the 1996 byte limit will there by a problem, but this is properly reported by the library and seems like fine behaviour to me.

With regards to the string padding, I thought that the best way to handle this would be to add a new string attribute which switches on/off padding to an even number of bytes. This defaults to on for all PLC types except Omron. One slight concern that I have with my implementation is that this also effects padding of other datatypes. However I think all datatypes except strings are an even number of bytes, even WORDS which are sent as two bytes? Anyway, if there is a way to check for the the datatype then let me know. I have also tested writing to a struct containing an odd number of bytes due to an odd sized string and this also works fine without the even byte padding.

I have tested this implementation on Omron NJ and it fixes the issue where for example a 5 byte string is sent as 6 bytes due to the even padding which makes the actual size contradict the string length specified. I have not tested on any other PLC types, but as it defaults to the old behaviour, there should be no effect.

Let me know what you think, or if you want any changes! 