### PR TITLE
Added response packet size calculation and checking when adding reque…

### DIFF
--- a/src/protocols/ab/ab_common.c
+++ b/src/protocols/ab/ab_common.c
@@ -218,27 +218,32 @@ plc_tag_p ab_tag_create(attr attribs, void (*tag_callback_func)(int32_t tag_id, 
     case AB_PLC_PLC5:
         tag->use_connected_msg = 0;
         tag->allow_packing = 0;
+        tag->supports_fragmented_read = 0;
         break;
 
     case AB_PLC_SLC:
         tag->use_connected_msg = 0;
         tag->allow_packing = 0;
+        tag->supports_fragmented_read = 0;
         break;
 
     case AB_PLC_MLGX:
         tag->use_connected_msg = 0;
         tag->allow_packing = 0;
+        tag->supports_fragmented_read = 0;
         break;
 
     case AB_PLC_LGX_PCCC:
         tag->use_connected_msg = 0;
         tag->allow_packing = 0;
+        tag->supports_fragmented_read = 0;
         break;
 
     case AB_PLC_LGX:
         /* default to requiring a connection and allowing packing. */
         tag->use_connected_msg = attr_get_int(attribs,"use_connected_msg", 1);
         tag->allow_packing = attr_get_int(attribs, "allow_packing", 1);
+        tag->supports_fragmented_read = 1;
         break;
 
     case AB_PLC_MICRO800:
@@ -248,6 +253,7 @@ plc_tag_p ab_tag_create(attr attribs, void (*tag_callback_func)(int32_t tag_id, 
 
         /* Micro800 cannot pack requests. */
         tag->allow_packing = 0;
+        tag->supports_fragmented_read = 1;
         break;
 
     case AB_PLC_OMRON_NJNX:
@@ -258,6 +264,7 @@ plc_tag_p ab_tag_create(attr attribs, void (*tag_callback_func)(int32_t tag_id, 
          * whether the results will fit or not.
          */
         tag->allow_packing = attr_get_int(attribs, "allow_packing", 0);
+        tag->supports_fragmented_read = 0;
         break;
 
     default:
@@ -1187,9 +1194,3 @@ int check_write_request_status(ab_tag_p tag, ab_request_p request)
 
     return rc;
 }
-
-
-
-
-
-

--- a/src/protocols/ab/eip_cip.c
+++ b/src/protocols/ab/eip_cip.c
@@ -488,6 +488,13 @@ int build_read_request_connected(ab_tag_p tag, int byte_offset)
 
     req->allow_packing = tag->allow_packing;
 
+    /* set the response size to the size of data from the previous read */
+    req->response_capacity = tag->size;
+
+    /* if this is the first read of the tag then we do not know the size of the response data and cannot use packing unless the plc supports fragmented reads*/
+    req->first_read = tag->first_read;
+    req->supports_fragmented_read = tag->supports_fragmented_read;
+
     /* add the request to the session's list. */
     rc = session_add_request(tag->session, req);
 
@@ -626,6 +633,13 @@ int build_read_request_unconnected(ab_tag_p tag, int byte_offset)
 
     /* allow packing if the tag allows it. */
     req->allow_packing = tag->allow_packing;
+
+    /* set the response size to the size of data from the previous read */
+    req->response_capacity = tag->size;
+
+    /* if this is the first read of the tag then we do not know the size of the response data and cannot use packing unless the plc supports fragmented reads*/
+    req->first_read = tag->first_read;
+    req->supports_fragmented_read = tag->supports_fragmented_read;
 
     /* add the request to the session's list. */
     rc = session_add_request(tag->session, req);
@@ -776,6 +790,9 @@ int build_write_bit_request_connected(ab_tag_p tag)
 
     /* allow packing if the tag allows it. */
     req->allow_packing = tag->allow_packing;
+
+    /* sets the expected size of the response message */
+    req->response_capacity = 0;
 
     /* add the request to the session's list. */
     rc = session_add_request(tag->session, req);
@@ -965,6 +982,9 @@ int build_write_bit_request_unconnected(ab_tag_p tag)
     /* allow packing if the tag allows it. */
     req->allow_packing = tag->allow_packing;
 
+    /* sets the expected size of the response message */
+    req->response_capacity = 0;
+
     /* add the request to the session's list. */
     rc = session_add_request(tag->session, req);
 
@@ -1112,6 +1132,9 @@ int build_write_request_connected(ab_tag_p tag, int byte_offset)
 
     /* allow packing if the tag allows it. */
     req->allow_packing = tag->allow_packing;
+
+    /* sets the expected size of the response message */
+    req->response_capacity = 0;
 
     /* add the request to the session's list. */
     rc = session_add_request(tag->session, req);
@@ -1293,6 +1316,9 @@ int build_write_request_unconnected(ab_tag_p tag, int byte_offset)
 
     /* allow packing if the tag allows it. */
     req->allow_packing = tag->allow_packing;
+
+    /* sets the expected size of the response message */
+    req->response_capacity = 0;
 
     /* add the request to the session's list. */
     rc = session_add_request(tag->session, req);

--- a/src/protocols/ab/session.c
+++ b/src/protocols/ab/session.c
@@ -1380,7 +1380,9 @@ int process_requests(ab_session_p session)
     ab_request_p request = NULL;
     ab_request_p bundled_requests[MAX_REQUESTS] = {NULL};
     int num_bundled_requests = 0;
-    int remaining_space = 0;
+    int remaining_request_space = 0;
+    int remaining_response_space = 0;
+    int allow_packing = 0;
 
     debug_set_tag_id(0);
 
@@ -1408,28 +1410,42 @@ int process_requests(ab_session_p session)
             /* if there are still requests after purging all the aborted requests, process them. */
 
             /* how much space do we have to work with. */
-            remaining_space = session->max_payload_size - (int)sizeof(cip_multi_req_header);
+            remaining_request_space = session->max_payload_size - (int)sizeof(cip_multi_req_header);
+
+             /* -2 bytes for the msp (multi service packet) number of packets and -4 bytes for the cip response header,
+              * we later subtract 2 bytes for each packet, this is to allow for the INT offset to the packet within the msp */
+            remaining_response_space = session->max_payload_size - 2 - 4;
 
             if(vector_length(session->requests)) {
                 do {
                     request = vector_get(session->requests, 0);
 
-                    remaining_space = remaining_space - get_payload_size(request);
+                    remaining_request_space = remaining_request_space - get_payload_size(request);
+
+                    /* calculate if all of the response data from the packed requests will fit into a single response packet. 
+                     * the -8 bytes is the maximum padding between packets, the -2 bytes is from the offset integer which stores the
+                     * offset to this packet */
+                    remaining_response_space = remaining_response_space - request->response_capacity - 8 - 2; 
+
+                    /* The tag must have packing enabled and the plc must either support fragmented reads or this tag must have been read 
+                     * before, so that its response size is known */
+                    allow_packing = request->allow_packing && (request->supports_fragmented_read || !request->first_read);
 
                     /*
                      * If we have a non-packable request, only queue it if it is the first one.
-                     * If the request is packable, keep queuing as long as there is space.
+                     * If the request is packable, keep queuing as long as there is space in both the 
+                     * request packet and the response packet if fragmented reads is not supported.
                      */
 
-                    if(num_bundled_requests == 0 || (request->allow_packing && remaining_space > 0)) {
-                        //pdebug(DEBUG_DETAIL, "packed %d requests with remaining space %d", num_bundled_requests+1, remaining_space);
+                    if(num_bundled_requests == 0 || (allow_packing && remaining_request_space > 0 && (remaining_response_space >= 0 || request->supports_fragmented_read))) {
+                        //pdebug(DEBUG_DETAIL, "packed %d requests with remaining request space %d and remaining response space %d", num_bundled_requests+1, remaining_request_space, remaining_response_space);
                         bundled_requests[num_bundled_requests] = request;
                         num_bundled_requests++;
 
                         /* remove it from the queue. */
                         vector_remove(session->requests, 0);
                     }
-                } while(vector_length(session->requests) && remaining_space > 0 && num_bundled_requests < MAX_REQUESTS && request->allow_packing);
+                } while(vector_length(session->requests) && remaining_request_space > 0 && num_bundled_requests < MAX_REQUESTS && allow_packing && (remaining_response_space >= 0 || request->supports_fragmented_read));
             } else {
                 pdebug(DEBUG_DETAIL, "All requests in queue were aborted, nothing to do.");
             }

--- a/src/protocols/ab/session.h
+++ b/src/protocols/ab/session.h
@@ -131,6 +131,10 @@ struct ab_request_t {
     /* used by the background thread for incrementally getting data */
     int request_size; /* total bytes, not just data */
     int request_capacity;
+    int response_capacity; /* Size of data we expect to be returned by this request */
+
+    int first_read;
+    int supports_fragmented_read;
     uint8_t *data;
 };
 

--- a/src/protocols/ab/tag.h
+++ b/src/protocols/ab/tag.h
@@ -113,6 +113,7 @@ struct ab_tag_t {
     int offset;
 
     int allow_packing;
+    int supports_fragmented_read;
 
     /* flags for operations */
     int read_in_progress;


### PR DESCRIPTION
…sts to a msp request.

Hi Kyle, these changes are to address [issue 454]( https://github.com/libplctag/libplctag/issues/454). What I have done is modified the code which adds multiple packets into a multiple service packet (msp) read/write request, to keep track of the size of the data which is expected to be returned. After each tag is read once, we now know the size of this data (assuming it hasnt changed between reads). I have used this size as well as adding some extra space to account for the embedded cip headers, to track how big the response packet is expected to be. For PLCs where fragmented reads is not supported (ie omron), all of the response data must fit into a single packet, these changes should stop the response data being too big for a single packet.

Currently there is no protection against this, other than defaulting allow_packing to be switched off, so these changes will add some protection. However if data grows between reads for some reason (this can be the case for Omron strings), then this protection will fail and there will be an error returned. So it would be a good idea to add this caveat to the documentation somewhere.

PLCs which support fragmented reads should be unaffected by these changes. Could you check that I have correctly identified which PLCs support fragmented reads? I am not familiar with the alan bradley PLCs. Also I have not tested whether this protection works for other PLCs which support message packing but not fragmented reads (i think it should). I have tested with my Omron NJ and have been able to pack 11 read requests into a msp and successfully read a single 1994 byte response msp.

Let me know what you think, 
Cheers Phil