### PR TITLE
Fix #486.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,8 +12,8 @@ jobs:
     runs-on: ubuntu-latest
 
     env:
-      VERSION: "2.6.2"
-      ARTIFACT: "libplctag_2.6.2_ubuntu_x64"
+      VERSION: "2.6.3"
+      ARTIFACT: "libplctag_2.6.3_ubuntu_x64"
       BUILD: "${{ github.workspace }}/build"
       DIST: "${{ github.workspace }}/build/bin_dist"
       BRANCH: ${{ github.head_ref || github.ref_name }}
@@ -130,8 +130,8 @@ jobs:
     runs-on: ubuntu-latest
 
     env:
-      VERSION: "2.6.2"
-      ARTIFACT: "libplctag_2.6.2_ubuntu_x86"
+      VERSION: "2.6.3"
+      ARTIFACT: "libplctag_2.6.3_ubuntu_x86"
       BUILD: "${{ github.workspace }}/build"
       DIST: "${{ github.workspace }}/build/bin_dist"
       BRANCH: ${{ github.head_ref || github.ref_name }}
@@ -247,8 +247,8 @@ jobs:
     runs-on: macos-latest
 
     env:
-      VERSION: "2.6.2"
-      ARTIFACT: "libplctag_2.6.2_macos_x64"
+      VERSION: "2.6.3"
+      ARTIFACT: "libplctag_2.6.3_macos_x64"
       BUILD: "${{ github.workspace }}/build"
       DIST: "${{ github.workspace }}/build/bin_dist"
       BRANCH: ${{ github.head_ref || github.ref_name }}
@@ -361,8 +361,8 @@ jobs:
     runs-on: macos-latest
 
     env:
-      VERSION: "2.6.2"
-      ARTIFACT: "libplctag_2.6.2_macos_aarch64"
+      VERSION: "2.6.3"
+      ARTIFACT: "libplctag_2.6.3_macos_aarch64"
       BUILD: "${{ github.workspace }}/build"
       DIST: "${{ github.workspace }}/build/bin_dist"
       BRANCH: ${{ github.head_ref || github.ref_name }}
@@ -396,8 +396,8 @@ jobs:
     runs-on: windows-2019
 
     env:
-      VERSION: "2.6.2"
-      ARTIFACT: "libplctag_2.6.2_windows_x64"
+      VERSION: "2.6.3"
+      ARTIFACT: "libplctag_2.6.3_windows_x64"
       BUILD: "${{ github.workspace }}\\build"
       DIST: "${{ github.workspace }}\\build\\bin_dist"
       BRANCH: ${{ github.head_ref || github.ref_name }}
@@ -518,8 +518,8 @@ jobs:
     runs-on: windows-2019
 
     env:
-      VERSION: "2.6.2"
-      ARTIFACT: "libplctag_2.6.2_windows_x86"
+      VERSION: "2.6.3"
+      ARTIFACT: "libplctag_2.6.3_windows_x86"
       BUILD: "${{ github.workspace }}/build"
       DIST: "${{ github.workspace }}/build/bin_dist"
       BRANCH: ${{ github.head_ref || github.ref_name }}
@@ -640,8 +640,8 @@ jobs:
     runs-on: windows-2019
 
     env:
-      VERSION: "2.6.2"
-      ARTIFACT: "libplctag_2.6.2_windows_Arm"
+      VERSION: "2.6.3"
+      ARTIFACT: "libplctag_2.6.3_windows_Arm"
       BUILD: "${{ github.workspace }}/build"
       DIST: "${{ github.workspace }}/build/bin_dist"
       BRANCH: ${{ github.head_ref || github.ref_name }}
@@ -676,8 +676,8 @@ jobs:
     runs-on: windows-2019
 
     env:
-      VERSION: "2.6.2"
-      ARTIFACT: "libplctag_2.6.2_windows_Arm64"
+      VERSION: "2.6.3"
+      ARTIFACT: "libplctag_2.6.3_windows_Arm64"
       BUILD: "${{ github.workspace }}/build"
       DIST: "${{ github.workspace }}/build/bin_dist"
       BRANCH: ${{ github.head_ref || github.ref_name }}
@@ -712,8 +712,8 @@ jobs:
     runs-on: ubuntu-latest
 
     env:
-      VERSION: "2.6.2"
-      ARTIFACT: "libplctag_2.6.2_linux_arm6hf"
+      VERSION: "2.6.3"
+      ARTIFACT: "libplctag_2.6.3_linux_arm6hf"
       BUILD: "${{ github.workspace }}/build"
       DIST: "${{ github.workspace }}/build/bin_dist"
       BRANCH: ${{ github.head_ref || github.ref_name }}
@@ -751,8 +751,8 @@ jobs:
     runs-on: ubuntu-latest
 
     env:
-      VERSION: "2.6.2"
-      ARTIFACT: "libplctag_2.6.2_linux_arm7l"
+      VERSION: "2.6.3"
+      ARTIFACT: "libplctag_2.6.3_linux_arm7l"
       BUILD: "${{ github.workspace }}/build"
       DIST: "${{ github.workspace }}/build/bin_dist"
       BRANCH: ${{ github.head_ref || github.ref_name }}
@@ -790,8 +790,8 @@ jobs:
     runs-on: ubuntu-latest
 
     env:
-      VERSION: "2.6.2"
-      ARTIFACT: "libplctag_2.6.2_linux_aarch64"
+      VERSION: "2.6.3"
+      ARTIFACT: "libplctag_2.6.3_linux_aarch64"
       BUILD: "${{ github.workspace }}/build"
       DIST: "${{ github.workspace }}/build/bin_dist"
       BRANCH: ${{ github.head_ref || github.ref_name }}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,7 +33,7 @@
 # the project is version 2.5
 set (libplctag_VERSION_MAJOR 2)
 set (libplctag_VERSION_MINOR 6)
-set (libplctag_VERSION_PATCH 2)
+set (libplctag_VERSION_PATCH 3)
 set (VERSION "${libplctag_VERSION_MAJOR}.${libplctag_VERSION_MINOR}.${libplctag_VERSION_PATCH}")
 
 set (LIB_NAME_SUFFIX "${libplctag_VERSION_MAJOR}.${libplctag_VERSION_MINOR}.${libplctag_VERSION_PATCH}")

--- a/src/examples/test_string.c
+++ b/src/examples/test_string.c
@@ -71,7 +71,7 @@ int main()
                                             plc_tag_get_int_attribute(0, "version_patch", -1));
 
     /* turn off debugging output. */
-    plc_tag_set_debug_level(PLCTAG_DEBUG_INFO);
+    plc_tag_set_debug_level(PLCTAG_DEBUG_DETAIL);
 
     tag = plc_tag_create(tag_string, DATA_TIMEOUT);
 
@@ -112,7 +112,7 @@ int main()
     free(str);
 
     /* now try to overwrite memory */
-    str_cap = plc_tag_get_string_capacity(tag, offset) + 1;
+    str_cap = plc_tag_get_string_capacity(tag, offset) + 10;
     str = (char *)malloc((size_t)(unsigned int)str_cap);
     if(!str) {
         fprintf(stderr, "Unable to allocate memory for the string write test!\n");
@@ -132,10 +132,10 @@ int main()
 
     /* try to set the string. */
     rc = plc_tag_set_string(tag, offset, str);
-    if(rc != PLCTAG_STATUS_OK) {
-        fprintf(stderr, "Correctly got error %s setting string!\n", plc_tag_decode_error(rc));
+    if(rc == PLCTAG_STATUS_OK) {
+        fprintf(stderr, "Setting the string succeeded.\n");
     } else {
-        fprintf(stderr, "Should have received an error trying to set string value with capacity longer than actual!\n");
+        fprintf(stderr, "Got error %s setting string!\n", plc_tag_decode_error(rc));
         free(str);
         plc_tag_destroy(tag);
         return PLCTAG_ERR_BAD_STATUS;
@@ -157,21 +157,9 @@ int main()
         return PLCTAG_ERR_BAD_STATUS;
     }
 
-    // /* try to write it. */
-    // rc = plc_tag_write(tag, DATA_TIMEOUT);
-    // if(rc != PLCTAG_STATUS_OK) {
-    //     fprintf(stderr, "Error %s writing string!\n", plc_tag_decode_error(rc));
-    //     free(str);
-    //     plc_tag_destroy(tag);
-    //     return rc;
-    // }
-
-
     /* we are done */
     free(str);
     plc_tag_destroy(tag);
 
     return 0;
 }
-
-

--- a/src/util/atomic_int.h
+++ b/src/util/atomic_int.h
@@ -35,6 +35,8 @@
 
 #include <platform.h>
 
+#define ATOMIC_INT_STATIC_INIT {0}
+
 typedef struct { lock_t lock; volatile int val; } atomic_int;
 
 extern void atomic_init(atomic_int *a, int new_val);

--- a/src/util/rc.c
+++ b/src/util/rc.c
@@ -160,10 +160,10 @@ void *rc_inc_impl(const char *func, int line_num, void *data)
     refcount_p rc = NULL;
     char *result = NULL;
 
-    pdebug(DEBUG_SPEW,"Starting, called from %s:%d for %p",func, line_num, data);
+    pdebug(DEBUG_DETAIL,"Starting, called from %s:%d for %p",func, line_num, data);
 
     if(!data) {
-        pdebug(DEBUG_SPEW,"Invalid pointer passed from %s:%d!", func, line_num);
+        pdebug(DEBUG_WARN,"Invalid pointer passed from %s:%d!", func, line_num);
         return result;
     }
 
@@ -183,9 +183,9 @@ void *rc_inc_impl(const char *func, int line_num, void *data)
     }
 
     if(!result) {
-        pdebug(DEBUG_SPEW,"Invalid ref count (%d) from call at %s line %d!  Unable to take strong reference.", count, func, line_num);
+        pdebug(DEBUG_DETAIL,"Invalid ref count (%d) from call at %s line %d!  Unable to take strong reference.", count, func, line_num);
     } else {
-        pdebug(DEBUG_SPEW,"Ref count is %d for %p.", count, data);
+        pdebug(DEBUG_DETAIL,"Ref count is %d for %p.", count, data);
     }
 
     /* return the result pointer. */
@@ -211,10 +211,10 @@ void *rc_dec_impl(const char *func, int line_num, void *data)
     int invalid = 0;
     refcount_p rc = NULL;
 
-    pdebug(DEBUG_SPEW,"Starting, called from %s:%d for %p",func, line_num, data);
+    pdebug(DEBUG_DETAIL,"Starting, called from %s:%d for %p",func, line_num, data);
 
     if(!data) {
-        pdebug(DEBUG_SPEW,"Null reference passed from %s:%d!", func, line_num);
+        pdebug(DEBUG_WARN,"Null reference passed from %s:%d!", func, line_num);
         return NULL;
     }
 
@@ -235,7 +235,7 @@ void *rc_dec_impl(const char *func, int line_num, void *data)
     if(invalid) {
         pdebug(DEBUG_WARN,"Reference has invalid count %d!", count);
     } else {
-        pdebug(DEBUG_SPEW,"Ref count is %d for %p.", count, data);
+        pdebug(DEBUG_DETAIL,"Ref count is %d for %p.", count, data);
 
         /* clean up only if count is zero. */
         if(rc && count <= 0) {


### PR DESCRIPTION
Fixes issue #486.  Hopefully.

Also fixed some missing rc_dec(tag) lines that were missing.  This led to leaked tags and the main session thread not shutting down.

Fixed test_string.c.  It certainly was not working before.