### PR TITLE
plc_tag_set_string() feature additions

### DIFF
--- a/src/examples/test_string.c
+++ b/src/examples/test_string.c
@@ -46,7 +46,8 @@
 
 #define REQUIRED_VERSION 2,4,10
 
-static const char *tag_string = "protocol=ab-eip&gateway=10.206.1.40&path=1,0&plc=ControlLogix&name=CB_Txt[0,0]";
+// static const char *tag_string = "protocol=ab-eip&gateway=10.206.1.40&path=1,0&plc=ControlLogix&name=CB_Txt[0,0]&str_is_counted=1&str_count_word_bytes=4&str_is_fixed_length=1&str_max_capacity=16&str_total_length=20&str_pad_bytes=0";
+static const char *tag_string = "protocol=ab-eip&gateway=10.206.1.40&path=1,0&plc=ControlLogix&name=CB_Txt[0,0]&str_is_counted=1&str_count_word_bytes=4&str_is_fixed_length=0&str_max_capacity=16&str_total_length=0&str_pad_bytes=0";
 
 #define DATA_TIMEOUT 5000
 
@@ -133,7 +134,23 @@ int main()
     /* try to set the string. */
     rc = plc_tag_set_string(tag, offset, str);
     if(rc == PLCTAG_STATUS_OK) {
-        fprintf(stderr, "Setting the string succeeded.\n");
+        fprintf(stderr, "Setting the tiny string succeeded.\n");
+    } else {
+        fprintf(stderr, "Got error %s setting string!\n", plc_tag_decode_error(rc));
+        free(str);
+        plc_tag_destroy(tag);
+        return PLCTAG_ERR_BAD_STATUS;
+    }
+
+    /* put in a larger, but still valid, string */
+    for(int i=0; (i < 6) && i < (str_cap - 1); i++) {
+        str[i] = (char)(0x30 + (i % 10)); /* 01234567890123456789... */
+    }
+
+    /* try to set the string. */
+    rc = plc_tag_set_string(tag, offset, str);
+    if(rc == PLCTAG_STATUS_OK) {
+        fprintf(stderr, "Setting the small string succeeded.\n");
     } else {
         fprintf(stderr, "Got error %s setting string!\n", plc_tag_decode_error(rc));
         free(str);

--- a/src/util/rc.c
+++ b/src/util/rc.c
@@ -160,7 +160,7 @@ void *rc_inc_impl(const char *func, int line_num, void *data)
     refcount_p rc = NULL;
     char *result = NULL;
 
-    pdebug(DEBUG_DETAIL,"Starting, called from %s:%d for %p",func, line_num, data);
+    pdebug(DEBUG_SPEW,"Starting, called from %s:%d for %p",func, line_num, data);
 
     if(!data) {
         pdebug(DEBUG_WARN,"Invalid pointer passed from %s:%d!", func, line_num);
@@ -183,9 +183,9 @@ void *rc_inc_impl(const char *func, int line_num, void *data)
     }
 
     if(!result) {
-        pdebug(DEBUG_DETAIL,"Invalid ref count (%d) from call at %s line %d!  Unable to take strong reference.", count, func, line_num);
+        pdebug(DEBUG_WARN,"Invalid ref count (%d) from call at %s line %d!  Unable to take strong reference.", count, func, line_num);
     } else {
-        pdebug(DEBUG_DETAIL,"Ref count is %d for %p.", count, data);
+        pdebug(DEBUG_SPEW,"Ref count is %d for %p.", count, data);
     }
 
     /* return the result pointer. */
@@ -211,7 +211,7 @@ void *rc_dec_impl(const char *func, int line_num, void *data)
     int invalid = 0;
     refcount_p rc = NULL;
 
-    pdebug(DEBUG_DETAIL,"Starting, called from %s:%d for %p",func, line_num, data);
+    pdebug(DEBUG_SPEW,"Starting, called from %s:%d for %p",func, line_num, data);
 
     if(!data) {
         pdebug(DEBUG_WARN,"Null reference passed from %s:%d!", func, line_num);
@@ -235,7 +235,7 @@ void *rc_dec_impl(const char *func, int line_num, void *data)
     if(invalid) {
         pdebug(DEBUG_WARN,"Reference has invalid count %d!", count);
     } else {
-        pdebug(DEBUG_DETAIL,"Ref count is %d for %p.", count, data);
+        pdebug(DEBUG_SPEW,"Ref count is %d for %p.", count, data);
 
         /* clean up only if count is zero. */
         if(rc && count <= 0) {


### PR DESCRIPTION
plc_tag_set_string() will now expand or contract the string's part of the tag buffer if the new string value is longer or shorter than the old one.  This is only true if the string type is not fixed size.