### PR TITLE
Added msp response size check before adding new requests to msp with …

### DIFF
--- a/src/protocols/omron/conn.h
+++ b/src/protocols/omron/conn.h
@@ -142,6 +142,10 @@ struct omron_request_t {
     /* used by the background thread for incrementally getting data */
     int request_size; /* total bytes, not just data */
     int request_capacity;
+    int response_size; /* size of data we expect to be returned by this request */
+
+    int first_read; /* whether this tag is being read for the first time and its size is therefor unknown*/
+    int supports_fragmented_read; /* if fragmented read is supported then we do not need to worry about the response*/
     uint8_t *data;
 };
 

--- a/src/protocols/omron/omron_common.c
+++ b/src/protocols/omron/omron_common.c
@@ -266,6 +266,7 @@ plc_tag_p omron_tag_create(attr attribs, void (*tag_callback_func)(int32_t tag_i
 
     tag->use_connected_msg = 1;
     tag->allow_packing = attr_get_int(attribs, "allow_packing", 0);
+    tag->supports_fragmented_read = 0; /* fragmented read is not currently supported */
 
     /* pass the connection requirement since it may be overridden above. */
     attr_set_int(attribs, "use_connected_msg", tag->use_connected_msg);

--- a/src/protocols/omron/omron_standard_tag.c
+++ b/src/protocols/omron/omron_standard_tag.c
@@ -410,6 +410,13 @@ int build_read_request_connected(omron_tag_p tag, int byte_offset)
 
     req->allow_packing = tag->allow_packing;
 
+    /* set the response size to the size of data from the previous read */
+    req->response_size = tag->size;
+
+    /* if this is the first read of the tag then we do not know the size of the response data and cannot use packing unless the plc supports fragmented reads*/
+    req->first_read = tag->first_read;
+    req->supports_fragmented_read = tag->supports_fragmented_read;
+
     /* add the request to the conn's list. */
     rc = conn_add_request(tag->conn, req);
 
@@ -541,6 +548,13 @@ int build_read_request_unconnected(omron_tag_p tag, int byte_offset)
 
     /* allow packing if the tag allows it. */
     req->allow_packing = tag->allow_packing;
+
+    /* set the response size to the size of data from the previous read */
+    req->response_size = tag->size;
+
+    /* if this is the first read of the tag then we do not know the size of the response data and cannot use packing unless the plc supports fragmented reads*/
+    req->first_read = tag->first_read;
+    req->supports_fragmented_read = tag->supports_fragmented_read;
 
     /* add the request to the conn's list. */
     rc = conn_add_request(tag->conn, req);

--- a/src/protocols/omron/tag.h
+++ b/src/protocols/omron/tag.h
@@ -109,6 +109,7 @@ struct omron_tag_t {
     int offset;
 
     int allow_packing;
+    int supports_fragmented_read;
 
     /* flags for operations */
     int read_in_progress;


### PR DESCRIPTION
…allow_packing=1 and fragmented reads disabled

This is a fix for #454. This checks for conditions where adding additional packets to a multi-service-packet (msp) message would cause the response packet to exceed the maximum size of an ethernet/IP message.

If a tag is being read for the first time, we do not add it to a msp as we dont know its size and cant guarantee that it will fit into the response packet. So we just send it as a normal, single request.

If a tag is not being read for the first time, we know the size of its response data. We use this size to check if there is room in the response before adding the request to the msp. If there is not room then we send the previous msp and start a new one.

There is an exception to the above, if fragmented reads are supported, it does not matter if there is not room in a single response as they will be packed into multiple requests. This is not yet supported for Omron, but will be in the future.

I have tested this and it stops the PLC_TAG_TOO_LARGE issue. The largest amount of data which can now theoretically be read in an msp, is two variables which are 978 bytes large giving a total of 1956 bytes of useful data. The expected extra bytes are (2 bytes for the msp count of packets, 4 bytes for the cip response header, 2 bytes per packet for the offset to the data within the msp and a variable number of bytes for the padding between the datatypes. We assume this padding is always 8 bytes just to be safe. We also add a 10 byte comfort blanket. Giving the total header/padding/extra data = 2+4+10+n*(8+2+dataSize). Where n is the number of requests in the msp. The optimal situation is n=2 and dataSize=978 which gives 2 bytes of spare room and 1956 bytes of useful data in the msp, which is 98% efficient. If dataSize=980, then we cannot fit two requests into the msp and I have tested this.