### PR TITLE
Fix #510 (miss-matched tag names)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,8 +12,8 @@ jobs:
     runs-on: ubuntu-latest
 
     env:
-      VERSION: "2.6.2"
-      ARTIFACT: "libplctag_2.6.2_ubuntu_x64"
+      VERSION: "2.6.3"
+      ARTIFACT: "libplctag_2.6.3_ubuntu_x64"
       BUILD: "${{ github.workspace }}/build"
       DIST: "${{ github.workspace }}/build/bin_dist"
       BRANCH: ${{ github.head_ref || github.ref_name }}
@@ -130,8 +130,8 @@ jobs:
     runs-on: ubuntu-latest
 
     env:
-      VERSION: "2.6.2"
-      ARTIFACT: "libplctag_2.6.2_ubuntu_x86"
+      VERSION: "2.6.3"
+      ARTIFACT: "libplctag_2.6.3_ubuntu_x86"
       BUILD: "${{ github.workspace }}/build"
       DIST: "${{ github.workspace }}/build/bin_dist"
       BRANCH: ${{ github.head_ref || github.ref_name }}
@@ -247,8 +247,8 @@ jobs:
     runs-on: macos-latest
 
     env:
-      VERSION: "2.6.2"
-      ARTIFACT: "libplctag_2.6.2_macos_x64"
+      VERSION: "2.6.3"
+      ARTIFACT: "libplctag_2.6.3_macos_x64"
       BUILD: "${{ github.workspace }}/build"
       DIST: "${{ github.workspace }}/build/bin_dist"
       BRANCH: ${{ github.head_ref || github.ref_name }}
@@ -361,8 +361,8 @@ jobs:
     runs-on: macos-latest
 
     env:
-      VERSION: "2.6.2"
-      ARTIFACT: "libplctag_2.6.2_macos_aarch64"
+      VERSION: "2.6.3"
+      ARTIFACT: "libplctag_2.6.3_macos_aarch64"
       BUILD: "${{ github.workspace }}/build"
       DIST: "${{ github.workspace }}/build/bin_dist"
       BRANCH: ${{ github.head_ref || github.ref_name }}
@@ -396,8 +396,8 @@ jobs:
     runs-on: windows-2019
 
     env:
-      VERSION: "2.6.2"
-      ARTIFACT: "libplctag_2.6.2_windows_x64"
+      VERSION: "2.6.3"
+      ARTIFACT: "libplctag_2.6.3_windows_x64"
       BUILD: "${{ github.workspace }}\\build"
       DIST: "${{ github.workspace }}\\build\\bin_dist"
       BRANCH: ${{ github.head_ref || github.ref_name }}
@@ -518,8 +518,8 @@ jobs:
     runs-on: windows-2019
 
     env:
-      VERSION: "2.6.2"
-      ARTIFACT: "libplctag_2.6.2_windows_x86"
+      VERSION: "2.6.3"
+      ARTIFACT: "libplctag_2.6.3_windows_x86"
       BUILD: "${{ github.workspace }}/build"
       DIST: "${{ github.workspace }}/build/bin_dist"
       BRANCH: ${{ github.head_ref || github.ref_name }}
@@ -640,8 +640,8 @@ jobs:
     runs-on: windows-2019
 
     env:
-      VERSION: "2.6.2"
-      ARTIFACT: "libplctag_2.6.2_windows_Arm"
+      VERSION: "2.6.3"
+      ARTIFACT: "libplctag_2.6.3_windows_Arm"
       BUILD: "${{ github.workspace }}/build"
       DIST: "${{ github.workspace }}/build/bin_dist"
       BRANCH: ${{ github.head_ref || github.ref_name }}
@@ -676,8 +676,8 @@ jobs:
     runs-on: windows-2019
 
     env:
-      VERSION: "2.6.2"
-      ARTIFACT: "libplctag_2.6.2_windows_Arm64"
+      VERSION: "2.6.3"
+      ARTIFACT: "libplctag_2.6.3_windows_Arm64"
       BUILD: "${{ github.workspace }}/build"
       DIST: "${{ github.workspace }}/build/bin_dist"
       BRANCH: ${{ github.head_ref || github.ref_name }}
@@ -712,8 +712,8 @@ jobs:
     runs-on: ubuntu-latest
 
     env:
-      VERSION: "2.6.2"
-      ARTIFACT: "libplctag_2.6.2_linux_arm6hf"
+      VERSION: "2.6.3"
+      ARTIFACT: "libplctag_2.6.3_linux_arm6hf"
       BUILD: "${{ github.workspace }}/build"
       DIST: "${{ github.workspace }}/build/bin_dist"
       BRANCH: ${{ github.head_ref || github.ref_name }}
@@ -751,8 +751,8 @@ jobs:
     runs-on: ubuntu-latest
 
     env:
-      VERSION: "2.6.2"
-      ARTIFACT: "libplctag_2.6.2_linux_arm7l"
+      VERSION: "2.6.3"
+      ARTIFACT: "libplctag_2.6.3_linux_arm7l"
       BUILD: "${{ github.workspace }}/build"
       DIST: "${{ github.workspace }}/build/bin_dist"
       BRANCH: ${{ github.head_ref || github.ref_name }}
@@ -790,8 +790,8 @@ jobs:
     runs-on: ubuntu-latest
 
     env:
-      VERSION: "2.6.2"
-      ARTIFACT: "libplctag_2.6.2_linux_aarch64"
+      VERSION: "2.6.3"
+      ARTIFACT: "libplctag_2.6.3_linux_aarch64"
       BUILD: "${{ github.workspace }}/build"
       DIST: "${{ github.workspace }}/build/bin_dist"
       BRANCH: ${{ github.head_ref || github.ref_name }}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,7 +33,7 @@
 # the project is version 2.5
 set (libplctag_VERSION_MAJOR 2)
 set (libplctag_VERSION_MINOR 6)
-set (libplctag_VERSION_PATCH 2)
+set (libplctag_VERSION_PATCH 3)
 set (VERSION "${libplctag_VERSION_MAJOR}.${libplctag_VERSION_MINOR}.${libplctag_VERSION_PATCH}")
 
 set (LIB_NAME_SUFFIX "${libplctag_VERSION_MAJOR}.${libplctag_VERSION_MINOR}.${libplctag_VERSION_PATCH}")

--- a/src/examples/test_string.c
+++ b/src/examples/test_string.c
@@ -44,12 +44,124 @@
  * STRING types are a DINT (4 bytes) followed by 82 bytes of characters.  Then two bytes of padding.
  */
 
-#define REQUIRED_VERSION 2,4,10
+/* need at least 2.6.3 for support for allow_field_resize flag. */
+#define REQUIRED_VERSION 2,6,3
 
-static const char *tag_string = "protocol=ab-eip&gateway=10.206.1.40&path=1,0&plc=ControlLogix&name=CB_Txt[0,0]";
+static const char *tag_string1 = "protocol=ab-eip&gateway=10.206.1.40&path=1,0&plc=ControlLogix&name=CB_Txt[0,0]&str_is_counted=1&str_count_word_bytes=4&str_is_fixed_length=0&str_max_capacity=16&str_total_length=0&str_pad_bytes=0";
+static const char *tag_string2 = "protocol=ab-eip&gateway=10.206.1.40&path=1,0&plc=ControlLogix&name=CB_Txt[0,0]&str_is_counted=1&str_count_word_bytes=4&str_is_fixed_length=0&str_max_capacity=16&str_total_length=0&str_pad_bytes=0&allow_field_resize=1";
 
 #define DATA_TIMEOUT 5000
 
+
+
+int test_string(const char *tag_string)
+{
+    int32_t tag = 0;
+    int rc;
+    int offset = 0;
+    int str_cap = 0;
+    char *str = NULL;
+
+    do {
+        tag = plc_tag_create(tag_string, DATA_TIMEOUT);
+
+        /* everything OK? */
+        if((rc = plc_tag_status(tag)) != PLCTAG_STATUS_OK) {
+            fprintf(stderr,"Error %s creating tag!\n", plc_tag_decode_error(rc));
+            break;
+        }
+
+        /* get the data */
+        rc = plc_tag_read(tag, DATA_TIMEOUT);
+        if(rc != PLCTAG_STATUS_OK) {
+            fprintf(stderr, "Error %s trying to read tag!\n", plc_tag_decode_error(rc));
+            break;
+        }
+
+        /* print out the data */
+        str_cap = plc_tag_get_string_length(tag, offset) + 1; /* +1 for the zero termination. */
+        str = (char *)malloc((size_t)(unsigned int)str_cap);
+        if(!str) {
+            fprintf(stderr, "Unable to allocate memory for the string!\n");
+            rc = PLCTAG_ERR_NO_MEM;
+            break;
+        }
+
+        rc = plc_tag_get_string(tag, offset, str, str_cap);
+        if(rc != PLCTAG_STATUS_OK) {
+            fprintf(stderr, "Error %s getting string value!\n", plc_tag_decode_error(rc));
+            break;
+        }
+
+        fprintf(stderr, "tag string data = '%s'\n", str);
+
+        free(str);
+
+        /* now try to overwrite memory */
+        str_cap = plc_tag_get_string_capacity(tag, offset) + 10;
+        str = (char *)malloc((size_t)(unsigned int)str_cap);
+        if(!str) {
+            fprintf(stderr, "Unable to allocate memory for the string write test!\n");
+            rc = PLCTAG_ERR_NO_MEM;
+            break;
+        }
+
+        /* clear out the string memory */
+        memset(str, 0, (unsigned int)str_cap);
+
+        /* try to write a shorter string but with a long capacity. */
+
+        /* put in a tiny string */
+        for(int i=0; (i < 2) && i < (str_cap - 1); i++) {
+            str[i] = (char)(0x30 + (i % 10)); /* 01234567890123456789... */
+        }
+
+        /* try to set the string. */
+        rc = plc_tag_set_string(tag, offset, str);
+        if(rc == PLCTAG_STATUS_OK) {
+            fprintf(stderr, "Setting the tiny string succeeded.\n");
+        } else {
+            fprintf(stderr, "Got error %s setting string!\n", plc_tag_decode_error(rc));
+            break;
+        }
+
+        /* put in a larger, but still valid, string */
+        for(int i=0; (i < 6) && i < (str_cap - 1); i++) {
+            str[i] = (char)(0x30 + (i % 10)); /* 01234567890123456789... */
+        }
+
+        /* try to set the string. */
+        rc = plc_tag_set_string(tag, offset, str);
+        if(rc == PLCTAG_STATUS_OK) {
+            fprintf(stderr, "Setting the small string succeeded.\n");
+        } else {
+            fprintf(stderr, "Got error %s setting string!\n", plc_tag_decode_error(rc));
+            break;
+        }
+
+        /* fill it completely with garbage */
+        for(int i=0; i < (str_cap - 1); i++) {
+            str[i] = (char)(0x30 + (i % 10)); /* 01234567890123456789... */
+        }
+
+        /* try to set the string. */
+        rc = plc_tag_set_string(tag, offset, str);
+        if(rc == PLCTAG_ERR_TOO_LARGE) {
+            fprintf(stderr, "Correctly got error %s setting string!\n", plc_tag_decode_error(rc));
+            rc = PLCTAG_STATUS_OK;
+        } else {
+            fprintf(stderr, "Should have error PLCTAG_ERR_TOO_LARGE but got %s trying to set string value with capacity longer than actual!\n", plc_tag_decode_error(rc));
+            rc = PLCTAG_ERR_BAD_STATUS;
+            break;
+        }
+    } while(0);
+
+    /* we are done */
+    free(str);
+    plc_tag_destroy(tag);
+
+    return rc;
+}
 
 int main()
 {
@@ -71,107 +183,21 @@ int main()
                                             plc_tag_get_int_attribute(0, "version_patch", -1));
 
     /* turn off debugging output. */
-    plc_tag_set_debug_level(PLCTAG_DEBUG_INFO);
+    plc_tag_set_debug_level(PLCTAG_DEBUG_DETAIL);
 
-    tag = plc_tag_create(tag_string, DATA_TIMEOUT);
-
-    /* everything OK? */
-    if((rc = plc_tag_status(tag)) != PLCTAG_STATUS_OK) {
-        fprintf(stderr,"Error %s creating tag!\n", plc_tag_decode_error(rc));
-        plc_tag_destroy(tag);
-        return rc;
+    /* we expect a failure here. */
+    rc = test_string(tag_string1);
+    if(rc != PLCTAG_ERR_NOT_ALLOWED) {
+        fprintf(stderr, "Unexpected failure error %s!", plc_tag_decode_error(rc));
+        return 1;
     }
 
-    /* get the data */
-    rc = plc_tag_read(tag, DATA_TIMEOUT);
+    /* We expect success here */
+    rc = test_string(tag_string2);
     if(rc != PLCTAG_STATUS_OK) {
-        fprintf(stderr, "Error %s trying to read tag!\n", plc_tag_decode_error(rc));
-        plc_tag_destroy(tag);
-        return rc;
+        fprintf(stderr, "Unexpected failure %s!", plc_tag_decode_error(rc));
+        return 1;
     }
-
-    /* print out the data */
-    str_cap = plc_tag_get_string_length(tag, offset) + 1; /* +1 for the zero termination. */
-    str = (char *)malloc((size_t)(unsigned int)str_cap);
-    if(!str) {
-        fprintf(stderr, "Unable to allocate memory for the string!\n");
-        plc_tag_destroy(tag);
-        return PLCTAG_ERR_NO_MEM;
-    }
-
-    rc = plc_tag_get_string(tag, offset, str, str_cap);
-    if(rc != PLCTAG_STATUS_OK) {
-        fprintf(stderr, "Error %s getting string value!\n", plc_tag_decode_error(rc));
-        free(str);
-        plc_tag_destroy(tag);
-        return rc;
-    }
-
-    fprintf(stderr, "tag string data = '%s'\n", str);
-
-    free(str);
-
-    /* now try to overwrite memory */
-    str_cap = plc_tag_get_string_capacity(tag, offset) + 1;
-    str = (char *)malloc((size_t)(unsigned int)str_cap);
-    if(!str) {
-        fprintf(stderr, "Unable to allocate memory for the string write test!\n");
-        plc_tag_destroy(tag);
-        return PLCTAG_ERR_NO_MEM;
-    }
-
-    /* clear out the string memory */
-    memset(str, 0, (unsigned int)str_cap);
-
-    /* try to write a shorter string but with a long capacity. */
-
-    /* put in a tiny string */
-    for(int i=0; (i < 2) && i < (str_cap - 1); i++) {
-        str[i] = (char)(0x30 + (i % 10)); /* 01234567890123456789... */
-    }
-
-    /* try to set the string. */
-    rc = plc_tag_set_string(tag, offset, str);
-    if(rc != PLCTAG_STATUS_OK) {
-        fprintf(stderr, "Correctly got error %s setting string!\n", plc_tag_decode_error(rc));
-    } else {
-        fprintf(stderr, "Should have received an error trying to set string value with capacity longer than actual!\n");
-        free(str);
-        plc_tag_destroy(tag);
-        return PLCTAG_ERR_BAD_STATUS;
-    }
-
-    /* fill it completely with garbage */
-    for(int i=0; i < (str_cap - 1); i++) {
-        str[i] = (char)(0x30 + (i % 10)); /* 01234567890123456789... */
-    }
-
-    /* try to set the string. */
-    rc = plc_tag_set_string(tag, offset, str);
-    if(rc != PLCTAG_STATUS_OK) {
-        fprintf(stderr, "Correctly got error %s setting string!\n", plc_tag_decode_error(rc));
-    } else {
-        fprintf(stderr, "Should have received an error trying to set string value with capacity longer than actual!\n");
-        free(str);
-        plc_tag_destroy(tag);
-        return PLCTAG_ERR_BAD_STATUS;
-    }
-
-    // /* try to write it. */
-    // rc = plc_tag_write(tag, DATA_TIMEOUT);
-    // if(rc != PLCTAG_STATUS_OK) {
-    //     fprintf(stderr, "Error %s writing string!\n", plc_tag_decode_error(rc));
-    //     free(str);
-    //     plc_tag_destroy(tag);
-    //     return rc;
-    // }
-
-
-    /* we are done */
-    free(str);
-    plc_tag_destroy(tag);
 
     return 0;
 }
-
-

--- a/src/lib/tag.h
+++ b/src/lib/tag.h
@@ -128,6 +128,7 @@ typedef void (*tag_extended_callback_func)(int32_t tag_id, int event, int status
                         uint8_t event_write_started: 1; \
                         uint8_t event_write_complete_enable: 1; \
                         uint8_t event_write_complete: 1; \
+                        uint8_t allow_field_resize:1; \
                         int8_t event_creation_complete_status; \
                         int8_t event_deletion_started_status; \
                         int8_t event_operation_aborted_status; \
@@ -269,4 +270,3 @@ static inline void tag_raise_event(plc_tag_p tag, int event, int8_t status)
             break;
     }
 }
-

--- a/src/protocols/omron/conn.h
+++ b/src/protocols/omron/conn.h
@@ -142,6 +142,10 @@ struct omron_request_t {
     /* used by the background thread for incrementally getting data */
     int request_size; /* total bytes, not just data */
     int request_capacity;
+    int response_size; /* size of data we expect to be returned by this request */
+
+    int first_read; /* whether this tag is being read for the first time and its size is therefor unknown*/
+    int supports_fragmented_read; /* if fragmented read is supported then we do not need to worry about the response*/
     uint8_t *data;
 };
 

--- a/src/protocols/omron/omron_common.c
+++ b/src/protocols/omron/omron_common.c
@@ -266,6 +266,7 @@ plc_tag_p omron_tag_create(attr attribs, void (*tag_callback_func)(int32_t tag_i
 
     tag->use_connected_msg = 1;
     tag->allow_packing = attr_get_int(attribs, "allow_packing", 0);
+    tag->supports_fragmented_read = 0; /* fragmented read is not currently supported */
 
     /* pass the connection requirement since it may be overridden above. */
     attr_set_int(attribs, "use_connected_msg", tag->use_connected_msg);

--- a/src/protocols/omron/omron_standard_tag.c
+++ b/src/protocols/omron/omron_standard_tag.c
@@ -410,6 +410,13 @@ int build_read_request_connected(omron_tag_p tag, int byte_offset)
 
     req->allow_packing = tag->allow_packing;
 
+    /* set the response size to the size of data from the previous read */
+    req->response_size = tag->size;
+
+    /* if this is the first read of the tag then we do not know the size of the response data and cannot use packing unless the plc supports fragmented reads*/
+    req->first_read = tag->first_read;
+    req->supports_fragmented_read = tag->supports_fragmented_read;
+
     /* add the request to the conn's list. */
     rc = conn_add_request(tag->conn, req);
 
@@ -541,6 +548,13 @@ int build_read_request_unconnected(omron_tag_p tag, int byte_offset)
 
     /* allow packing if the tag allows it. */
     req->allow_packing = tag->allow_packing;
+
+    /* set the response size to the size of data from the previous read */
+    req->response_size = tag->size;
+
+    /* if this is the first read of the tag then we do not know the size of the response data and cannot use packing unless the plc supports fragmented reads*/
+    req->first_read = tag->first_read;
+    req->supports_fragmented_read = tag->supports_fragmented_read;
 
     /* add the request to the conn's list. */
     rc = conn_add_request(tag->conn, req);

--- a/src/protocols/omron/tag.h
+++ b/src/protocols/omron/tag.h
@@ -109,6 +109,7 @@ struct omron_tag_t {
     int offset;
 
     int allow_packing;
+    int supports_fragmented_read;
 
     /* flags for operations */
     int read_in_progress;

--- a/src/tests/ab_server/src/cip.c
+++ b/src/tests/ab_server/src/cip.c
@@ -640,7 +640,7 @@ bool process_tag_segment(plc_s *plc, slice_s input, tag_def_s **tag, size_t *sta
     *tag = plc->tags;
 
     while(*tag) {
-        if(slice_match_string(tag_name, (*tag)->name)) {
+        if(slice_is_string(tag_name, (*tag)->name)) {
             info("Found tag %s", (*tag)->name);
             break;
         }

--- a/src/tests/ab_server/src/slice.h
+++ b/src/tests/ab_server/src/slice.h
@@ -68,7 +68,11 @@ inline static bool slice_match_bytes(slice_s s, const uint8_t *data, size_t data
     }
     return true;
 }
-inline static bool slice_match_string(slice_s s, const char *data) { return slice_match_bytes(s, (const uint8_t*)data, strlen(data)); }
+/* unlike slice_match_bytes, also checks the slice is not longer than the str */
+inline static bool slice_is_string(slice_s s, const char *str) {
+    size_t len = strlen(str);
+    return len == slice_len(s) && slice_match_bytes(s, (const uint8_t*)str, len);
+}
 
 inline static slice_s slice_from_slice(slice_s src, size_t start, size_t len) {
     ssize_t actual_start;

--- a/src/util/atomic_int.h
+++ b/src/util/atomic_int.h
@@ -35,6 +35,8 @@
 
 #include <platform.h>
 
+#define ATOMIC_INT_STATIC_INIT {0}
+
 typedef struct { lock_t lock; volatile int val; } atomic_int;
 
 extern void atomic_init(atomic_int *a, int new_val);

--- a/src/util/rc.c
+++ b/src/util/rc.c
@@ -163,7 +163,7 @@ void *rc_inc_impl(const char *func, int line_num, void *data)
     pdebug(DEBUG_SPEW,"Starting, called from %s:%d for %p",func, line_num, data);
 
     if(!data) {
-        pdebug(DEBUG_SPEW,"Invalid pointer passed from %s:%d!", func, line_num);
+        pdebug(DEBUG_WARN,"Invalid pointer passed from %s:%d!", func, line_num);
         return result;
     }
 
@@ -183,7 +183,7 @@ void *rc_inc_impl(const char *func, int line_num, void *data)
     }
 
     if(!result) {
-        pdebug(DEBUG_SPEW,"Invalid ref count (%d) from call at %s line %d!  Unable to take strong reference.", count, func, line_num);
+        pdebug(DEBUG_WARN,"Invalid ref count (%d) from call at %s line %d!  Unable to take strong reference.", count, func, line_num);
     } else {
         pdebug(DEBUG_SPEW,"Ref count is %d for %p.", count, data);
     }
@@ -214,7 +214,7 @@ void *rc_dec_impl(const char *func, int line_num, void *data)
     pdebug(DEBUG_SPEW,"Starting, called from %s:%d for %p",func, line_num, data);
 
     if(!data) {
-        pdebug(DEBUG_SPEW,"Null reference passed from %s:%d!", func, line_num);
+        pdebug(DEBUG_WARN,"Null reference passed from %s:%d!", func, line_num);
         return NULL;
     }
 


### PR DESCRIPTION
Make `ab_server` lookup tag names based on their entire name, not just their prefix. See single commit message for details.