### PR TITLE
Revert auto sync changes, add tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -130,6 +130,12 @@ jobs:
         echo "shut down server."
         killall ab_server -INT &> /dev/null
 
+    - name: Test Reconnect After Outage
+      run: |
+        cd ${{ env.DIST }}
+        echo "Test reconnect after outage"
+        ${{ env.DIST }}/test_reconnect_after_outage ./ab_server
+
     - name: Test Modbus
       run: |
         cd ${{ env.DIST }}
@@ -591,6 +597,13 @@ jobs:
         echo "shut down server."
         taskkill /F /IM ab_server.exe
         exit /b %test_result%
+      shell: cmd
+
+    - name: Test Reconnect After Outage
+      run: |
+        cd ${{ env.DIST }}
+        echo "Test reconnect after outage."
+        .\test_reconnect_after_outage .\ab_server.exe
       shell: cmd
 
     - name: Upload ZIP artifact

--- a/.github/workflows/ci.yml.in
+++ b/.github/workflows/ci.yml.in
@@ -130,6 +130,12 @@ jobs:
         echo "shut down server."
         killall ab_server -INT &> /dev/null
 
+    - name: Test Reconnect After Outage
+      run: |
+        cd ${{ env.DIST }}
+        echo "Test reconnect after outage"
+        ${{ env.DIST }}/test_reconnect_after_outage ./ab_server
+
     - name: Test Modbus
       run: |
         cd ${{ env.DIST }}
@@ -591,6 +597,13 @@ jobs:
         echo "shut down server."
         taskkill /F /IM ab_server.exe
         exit /b %test_result%
+      shell: cmd
+
+    - name: Test Reconnect After Outage
+      run: |
+        cd ${{ env.DIST }}
+        echo "Test reconnect after outage."
+        .\test_reconnect_after_outage .\ab_server.exe
       shell: cmd
 
     - name: Upload ZIP artifact

--- a/src/examples/CMakeLists.txt
+++ b/src/examples/CMakeLists.txt
@@ -37,7 +37,7 @@ set(EXAMPLE_EXECUTABLES
   test_alternate_tag_listing
   test_array_notation
   test_auto_sync
-  test_auto_sync_reconnect
+  test_reconnect_after_outage
   test_callback
   test_callback_ex
   test_callback_ex_logix
@@ -82,7 +82,7 @@ foreach(example ${EXAMPLE_EXECUTABLES})
     # Link with the static library and apply static linking flags
     target_link_libraries(${example} plctag_static ${EXTRA_LINKER_LIBS})
 
-    if(UNIX AND NOT APPLE) 
+    if(UNIX AND NOT APPLE)
         if(CMAKE_BUILD_TYPE STREQUAL "Debug")
             target_link_options(${example} PRIVATE -static ${EXTRA_LINK_FLAGS})
         else()

--- a/src/examples/test_auto_sync_reconnect.c
+++ b/src/examples/test_auto_sync_reconnect.c
@@ -48,10 +48,14 @@
 #define DATA_TIMEOUT (500)
 #define DISCONNECT_TIME_MS (3000)
 #define TEST_DURATION_MS (10000)
-#define READ_POLL_MS (100)
+#define AUTO_READ_POLL_MS (100)
+#define MANUAL_READ_TIMEOUT_MS (500)
 
 /* uses auto_sync_read_ms for automatic reads */
-#define TAG_ATTRIBS \
+#define AUTO_SYNC_TAG_ATTRIBS \
+    "protocol=ab-eip&gateway=127.0.0.1&path=1,0&plc=ControlLogix&elem_type=DINT&elem_count=1&name=TestBigArray[0]&auto_sync_read_ms=100"
+
+#define MANUAL_SYNC_TAG_ATTRIBS \
     "protocol=ab-eip&gateway=127.0.0.1&path=1,0&plc=ControlLogix&elem_type=DINT&elem_count=1&name=TestBigArray[0]&auto_sync_read_ms=100"
 
 #ifdef WINDOWS_PLATFORM
@@ -87,22 +91,21 @@ typedef struct {
 
 
 static void check_library_version(void);
-static void setup_tag(test_state_t *test_state);
+static void setup_tag(test_state_t *test_state, const char *tag_attribs);
 static void stop_server(void);
 static void start_server(test_state_t *test_state);
 static void do_disconnect(int64_t current_time, test_state_t *test_state);
 static void do_reconnect(int64_t current_time, test_state_t *test_state);
 static void tag_callback(int32_t tag_id, int event, int status, void *data);
-static void run_test(test_state_t *test_state);
+static int run_auto_test(const char *ab_server_cmd);
+static int run_manual_test(const char *ab_server_cmd);
 
 
 int main(int argc, char **argv) {
     const char *ab_server_cmd = NULL;
-    test_state_t test_state = {0};
 
     if(argc > 1) {
         ab_server_cmd = argv[1];
-        test_state.ab_server_cmd = ab_server_cmd;
     } else {
         log("Usage: %s <ab_server_command>\n", argv[0]);
         log("Example: %s \"./build/bin_dist/ab_server\"\n", argv[0]);
@@ -118,87 +121,21 @@ int main(int argc, char **argv) {
     log("Cleaning up any existing ab_server instances...\n");
     stop_server();
 
-    /* start the AB server first */
-    log("Starting AB server for the test...\n");
-    start_server(&test_state);
-
-    /* initialize test state */
-    test_state.start_time = compat_time_ms();
-    test_state.end_time = test_state.start_time + TEST_DURATION_MS;
-    test_state.disconnect_time = test_state.start_time + (TEST_DURATION_MS / 4); /* Disconnect after 25% of the test */
-    test_state.reconnect_time = 0;                                               /* Will be set when disconnect happens */
-    test_state.test_passed = 0;
-    test_state.reconnect_done = 0;
-
-    /* set up the tag and set the callback */
-    setup_tag(&test_state);
+    /* print status while waiting for test completion */
+    log("Running auto-sync test...\n");
+    if(run_auto_test(ab_server_cmd)) {
+        log("Auto-sync test failed!\n");
+        return 1;
+    }
 
     /* print status while waiting for test completion */
-    run_test(&test_state);
-
-    /* calculate the expected number of reads based on auto_sync_read_ms */
-    int expected_reads = TEST_DURATION_MS / READ_POLL_MS;
-
-    /* print results */
-    log("\nTest Results:\n");
-    log("Total reads started: %d, completed: %d, expected: %d\n", test_state.read_start_count, test_state.read_success_count,
-        expected_reads);
-    log("Read errors: %d\n", test_state.read_error_count);
-    log("Successful reads after reconnect: %d\n", test_state.read_success_after_reconnect);
-    log("Time from reconnect to end: %" PRId64 " ms\n", test_state.end_time - test_state.reconnect_time);
-
-    /* manually attempt to trigger a read after the test to verify the connection works */
-    log("Attempting a final manual read to verify connection state...\n");
-    int manual_read_rc = plc_tag_read(test_state.tag, 0);
-    if(manual_read_rc == PLCTAG_STATUS_OK) {
-        log("Manual read succeeded. Tag value: %d\n", plc_tag_get_int32(test_state.tag, 0));
-    } else {
-        log("Manual read failed with status: %s\n", plc_tag_decode_error(manual_read_rc));
+    log("Running manual-sync test...\n");
+    if(run_manual_test(ab_server_cmd)) {
+        log("Manual-sync test failed!\n");
+        return 1;
     }
 
-    /* log the count of successful reads after reconnect */
-    log("Final successful reads after reconnect: %d\n", test_state.read_success_after_reconnect);
-    log("Errors during disconnection period: %d\n", test_state.errors_during_disconnect);
-
-    /* clean up */
-    plc_tag_destroy(test_state.tag);
-
-    /* kill any remaining ab_server instances. */
-    log("Cleaning up ab_server...\n");
-    stop_server();
-
-    /* determine if test passed - needs both:
-     * 1. Successful reads after reconnect (showing auto_sync_read resumed)
-     * 2. Evidence of disconnection (either errors or pending reads)
-     */
-    int pending_operations = test_state.read_start_count - test_state.read_success_count;
-    int disconnect_evidence = test_state.errors_during_disconnect > 0;
-    int reconnect_success = test_state.read_success_after_reconnect > 0;
-
-    log("Disconnect evidence: %d errors, %d pending operations\n",
-        test_state.errors_after_reconnect - test_state.errors_before_disconnect, pending_operations);
-
-    test_state.test_passed = (reconnect_success && disconnect_evidence);
-
-    if(test_state.test_passed) {
-        log("TEST PASSED - Auto-sync reads successfully resumed after PLC reconnect\n");
-        log("             Detected %d disconnection issues and %d successful reads after reconnect\n",
-            test_state.errors_during_disconnect, test_state.read_success_after_reconnect);
-    } else {
-        log("TEST FAILED\n");
-
-        if(test_state.read_success_after_reconnect == 0) {
-            log("- No successful reads after PLC reconnect\n");
-            log("  The auto-sync reads aren't resuming correctly\n");
-        }
-
-        if(!disconnect_evidence) {
-            log("- No disconnection evidence detected\n");
-            log("  The disconnection simulation may not be working correctly\n");
-        }
-    }
-
-    return test_state.test_passed ? 0 : 1;
+    return 0;
 }
 
 
@@ -217,11 +154,11 @@ void check_library_version(void) {
 }
 
 
-void setup_tag(test_state_t *test_state) {
+void setup_tag(test_state_t *test_state, const char *tag_attribs) {
     int rc = PLCTAG_STATUS_OK;
 
     /* create tag */
-    test_state->tag = plc_tag_create(TAG_ATTRIBS, DATA_TIMEOUT);
+    test_state->tag = plc_tag_create_ex(tag_attribs, tag_callback, test_state, DATA_TIMEOUT);
     if(test_state->tag < 0) {
         log("Error %s creating tag!\n", plc_tag_decode_error(test_state->tag));
         exit(1);
@@ -232,19 +169,11 @@ void setup_tag(test_state_t *test_state) {
     /* verify auto_sync_read_ms setting is correctly set */
     int auto_sync_read_ms = plc_tag_get_int_attribute(test_state->tag, "auto_sync_read_ms", 0);
     log("Tag auto_sync_read_ms setting: %d ms\n", auto_sync_read_ms);
-
-    /* register the callback for tag events */
-    rc = plc_tag_register_callback_ex(test_state->tag, tag_callback, test_state);
-    if(rc != PLCTAG_STATUS_OK) {
-        log("Error %s registering callback!\n", plc_tag_decode_error(rc));
-        plc_tag_destroy(test_state->tag);
-        exit(1);
-    }
 }
 
 
 void start_server(test_state_t *test_state) {
-    char start_cmd[1024];
+    char start_cmd[1024] = {0};
 
     snprintf(start_cmd, sizeof(start_cmd), SERVER_START, test_state->ab_server_cmd);
 
@@ -363,49 +292,200 @@ void do_reconnect(int64_t current_time, test_state_t *test_state) {
 }
 
 
-void run_test(test_state_t *test_state) {
+int calc_test_stats(test_state_t *test_state) {
+    /* calculate the expected number of reads based on auto_sync_read_ms */
+    int expected_reads = TEST_DURATION_MS / AUTO_READ_POLL_MS;
+
+    /* print results */
+    log("\nTest Results:\n");
+    log("Total reads started: %d, completed: %d, expected: %d\n", test_state->read_start_count, test_state->read_success_count,
+        expected_reads);
+    log("Read errors: %d\n", test_state->read_error_count);
+    log("Successful reads after reconnect: %d\n", test_state->read_success_after_reconnect);
+    log("Time from reconnect to end: %" PRId64 " ms\n", test_state->end_time - test_state->reconnect_time);
+
+    /* manually attempt to trigger a read after the test to verify the connection works */
+    log("Attempting a final manual read to verify connection state...\n");
+    int manual_read_rc = plc_tag_read(test_state->tag, 0);
+    if(manual_read_rc == PLCTAG_STATUS_OK) {
+        log("Manual read succeeded. Tag value: %d\n", plc_tag_get_int32(test_state->tag, 0));
+    } else {
+        log("Manual read failed with status: %s\n", plc_tag_decode_error(manual_read_rc));
+    }
+
+    /* log the count of successful reads after reconnect */
+    log("Final successful reads after reconnect: %d\n", test_state->read_success_after_reconnect);
+    log("Errors during disconnection period: %d\n", test_state->errors_during_disconnect);
+
+    /*
+     * determine if test passed - needs both:
+     * 1. Successful reads after reconnect (showing auto_sync_read resumed)
+     * 2. Evidence of disconnection (either errors or pending reads)
+     */
+    int pending_operations = test_state->read_start_count - test_state->read_success_count;
+    int disconnect_evidence = test_state->errors_during_disconnect > 0;
+    int reconnect_success = test_state->read_success_after_reconnect > 0;
+
+    log("Disconnect evidence: %d errors, %d pending operations\n",
+        test_state->errors_after_reconnect - test_state->errors_before_disconnect, pending_operations);
+
+    test_state->test_passed = (reconnect_success && disconnect_evidence);
+
+    if(test_state->test_passed) {
+        log("TEST PASSED - Auto-sync reads successfully resumed after PLC reconnect\n");
+        log("             Detected %d disconnection issues and %d successful reads after reconnect\n",
+            test_state->errors_during_disconnect, test_state->read_success_after_reconnect);
+    } else {
+        log("TEST FAILED\n");
+
+        if(test_state->read_success_after_reconnect == 0) {
+            log("- No successful reads after PLC reconnect\n");
+            log("  The auto-sync reads aren't resuming correctly\n");
+        }
+
+        if(!disconnect_evidence) {
+            log("- No disconnection evidence detected\n");
+            log("  The disconnection simulation may not be working correctly\n");
+        }
+    }
+
+    return test_state->test_passed ? 0 : 1;
+}
+
+
+int run_auto_test(const char *ab_server_cmd) {
     int64_t current_time = 0;
     int64_t next_pct = 0;
+    test_state_t test_state = {0};
 
-    log("Test running for %dms...\n", TEST_DURATION_MS);
+    log("\nAuto tag test running for %dms...\n", TEST_DURATION_MS);
 
-    while((current_time = compat_time_ms()) < test_state->end_time) {
-        int64_t complete_pct = (current_time - test_state->start_time) * 100 / TEST_DURATION_MS;
+    /* initialize test state */
+    test_state.ab_server_cmd = ab_server_cmd;
+    test_state.start_time = compat_time_ms();
+    test_state.end_time = test_state.start_time + TEST_DURATION_MS;
+    test_state.disconnect_time = test_state.start_time + (TEST_DURATION_MS / 4); /* Disconnect after 25% of the test */
+    test_state.reconnect_time = 0;                                               /* Will be set when disconnect happens */
+    test_state.test_passed = 0;
+    test_state.reconnect_done = 0;
+
+    start_server(&test_state);
+
+    /* set up the tag and set the callback */
+    setup_tag(&test_state, AUTO_SYNC_TAG_ATTRIBS);
+
+    while((current_time = compat_time_ms()) < test_state.end_time) {
+        int64_t complete_pct = (current_time - test_state.start_time) * 100 / TEST_DURATION_MS;
 
         /* log stats every 5% */
         if(complete_pct >= next_pct) {
-            int tag_status = plc_tag_status(test_state->tag);
-            int64_t elapsed_ms = current_time - test_state->start_time;
+            int tag_status = plc_tag_status(test_state.tag);
+            int64_t elapsed_ms = current_time - test_state.start_time;
 
             next_pct = complete_pct + 5;
 
             log("\n[STATUS] Test progress: %" PRId64 "%% complete (elapsed: %" PRId64 " ms)\n", complete_pct, elapsed_ms);
             log("[STATUS] Tag status: %s\n", plc_tag_decode_error(tag_status));
-            log("[STATUS] Read stats: started=%d, completed=%d, timeouts=%d, errors=%d\n", test_state->read_start_count,
-                test_state->read_success_count, test_state->read_timeout_count, test_state->read_error_count);
+            log("[STATUS] Read stats: started=%d, completed=%d, timeouts=%d, errors=%d\n", test_state.read_start_count,
+                test_state.read_success_count, test_state.read_timeout_count, test_state.read_error_count);
 
             /* If we're past the reconnect time, print additional diagnostics */
-            if(test_state->reconnect_time > 0 && elapsed_ms > test_state->reconnect_time) {
+            if(test_state.reconnect_time > 0 && elapsed_ms > test_state.reconnect_time) {
                 log("[STATUS] Time since reconnect: %" PRId64 "ms, read completions after reconnect: %d\n",
-                    current_time - test_state->reconnect_time, test_state->read_success_after_reconnect);
+                    current_time - test_state.reconnect_time, test_state.read_success_after_reconnect);
             }
         }
 
         /* check if it's time to simulate a PLC disconnect */
-        if(test_state->disconnect_time > 0 && current_time >= test_state->disconnect_time && test_state->reconnect_time == 0) {
-            do_disconnect(current_time, test_state);
+        if(test_state.disconnect_time > 0 && current_time >= test_state.disconnect_time && test_state.reconnect_time == 0) {
+            do_disconnect(current_time, &test_state);
         }
 
         /* check if it's time to simulate a PLC reconnect - only do once */
-        if(test_state->reconnect_time > 0 && current_time >= test_state->reconnect_time && !test_state->reconnect_done) {
-            do_reconnect(current_time, test_state);
+        if(test_state.reconnect_time > 0 && current_time >= test_state.reconnect_time && !test_state.reconnect_done) {
+            do_reconnect(current_time, &test_state);
 
             /* there is a data race here but we do not need to be exact. */
-            test_state->reconnect_done = true;
+            test_state.reconnect_done = true;
         }
 
-        compat_sleep_ms(READ_POLL_MS / 2, NULL);
+        compat_sleep_ms(AUTO_READ_POLL_MS / 2, NULL);
     }
 
     log("[STATUS] Test completed.\n");
+
+    plc_tag_destroy(test_state.tag);
+
+    stop_server();
+
+    return calc_test_stats(&test_state);
+}
+
+
+int run_manual_test(const char *ab_server_cmd) {
+    int64_t current_time = 0;
+    int64_t next_pct = 0;
+    test_state_t test_state = {0};
+
+    log("\n\nManual tag test running for %dms...\n", TEST_DURATION_MS);
+
+    /* initialize test state */
+    test_state.ab_server_cmd = ab_server_cmd;
+    test_state.start_time = compat_time_ms();
+    test_state.end_time = test_state.start_time + TEST_DURATION_MS;
+    test_state.disconnect_time = test_state.start_time + (TEST_DURATION_MS / 4); /* Disconnect after 25% of the test */
+    test_state.reconnect_time = 0;                                               /* Will be set when disconnect happens */
+    test_state.test_passed = 0;
+    test_state.reconnect_done = 0;
+
+    start_server(&test_state);
+
+    /* set up the tag and set the callback */
+    setup_tag(&test_state, MANUAL_SYNC_TAG_ATTRIBS);
+
+    while((current_time = compat_time_ms()) < test_state.end_time) {
+        int64_t complete_pct = (current_time - test_state.start_time) * 100 / TEST_DURATION_MS;
+
+        /* log stats every 5% */
+        if(complete_pct >= next_pct) {
+            int tag_status = plc_tag_status(test_state.tag);
+            int64_t elapsed_ms = current_time - test_state.start_time;
+
+            next_pct = complete_pct + 5;
+
+            log("\n[STATUS] Test progress: %" PRId64 "%% complete (elapsed: %" PRId64 " ms)\n", complete_pct, elapsed_ms);
+            log("[STATUS] Tag status: %s\n", plc_tag_decode_error(tag_status));
+            log("[STATUS] Read stats: started=%d, completed=%d, timeouts=%d, errors=%d\n", test_state.read_start_count,
+                test_state.read_success_count, test_state.read_timeout_count, test_state.read_error_count);
+
+            /* If we're past the reconnect time, print additional diagnostics */
+            if(test_state.reconnect_time > 0 && elapsed_ms > test_state.reconnect_time) {
+                log("[STATUS] Time since reconnect: %" PRId64 "ms, read completions after reconnect: %d\n",
+                    current_time - test_state.reconnect_time, test_state.read_success_after_reconnect);
+            }
+        }
+
+        /* check if it's time to simulate a PLC disconnect */
+        if(test_state.disconnect_time > 0 && current_time >= test_state.disconnect_time && test_state.reconnect_time == 0) {
+            do_disconnect(current_time, &test_state);
+        }
+
+        /* check if it's time to simulate a PLC reconnect - only do once */
+        if(test_state.reconnect_time > 0 && current_time >= test_state.reconnect_time && !test_state.reconnect_done) {
+            do_reconnect(current_time, &test_state);
+
+            /* there is a data race here but we do not need to be exact. */
+            test_state.reconnect_done = true;
+        }
+
+        plc_tag_read(test_state.tag, MANUAL_READ_TIMEOUT_MS);
+    }
+
+    log("[STATUS] Test completed.\n");
+
+    plc_tag_destroy(test_state.tag);
+
+    stop_server();
+
+    return calc_test_stats(&test_state);
 }

--- a/src/examples/test_reconnect_after_outage.c
+++ b/src/examples/test_reconnect_after_outage.c
@@ -56,7 +56,7 @@
     "protocol=ab-eip&gateway=127.0.0.1&path=1,0&plc=ControlLogix&elem_type=DINT&elem_count=1&name=TestBigArray[0]&auto_sync_read_ms=100"
 
 #define MANUAL_SYNC_TAG_ATTRIBS \
-    "protocol=ab-eip&gateway=127.0.0.1&path=1,0&plc=ControlLogix&elem_type=DINT&elem_count=1&name=TestBigArray[0]&auto_sync_read_ms=100"
+    "protocol=ab-eip&gateway=127.0.0.1&path=1,0&plc=ControlLogix&elem_type=DINT&elem_count=1&name=TestBigArray[0]"
 
 #ifdef WINDOWS_PLATFORM
 #    define SERVER_START "start /B %s --plc=ControlLogix --path=1,0 --tag=TestBigArray:DINT[10] >nul 2>&1"
@@ -77,6 +77,7 @@ typedef struct {
     int64_t disconnect_time;
     int64_t reconnect_time;
     int32_t tag;
+    int read_timeout_ms;
     int read_start_count;
     int read_success_count;
     int read_timeout_count;
@@ -99,7 +100,7 @@ static void do_reconnect(int64_t current_time, test_state_t *test_state);
 static void tag_callback(int32_t tag_id, int event, int status, void *data);
 static int run_auto_test(const char *ab_server_cmd);
 static int run_manual_test(const char *ab_server_cmd);
-
+static void wait_until_time_ms(int64_t time_ms);
 
 int main(int argc, char **argv) {
     const char *ab_server_cmd = NULL;
@@ -122,14 +123,14 @@ int main(int argc, char **argv) {
     stop_server();
 
     /* print status while waiting for test completion */
-    log("Running auto-sync test...\n");
+    log("\n\nRunning auto-sync test...\n");
     if(run_auto_test(ab_server_cmd)) {
         log("Auto-sync test failed!\n");
         return 1;
     }
 
     /* print status while waiting for test completion */
-    log("Running manual-sync test...\n");
+    log("\n\nRunning manual-sync test...\n");
     if(run_manual_test(ab_server_cmd)) {
         log("Manual-sync test failed!\n");
         return 1;
@@ -155,8 +156,6 @@ void check_library_version(void) {
 
 
 void setup_tag(test_state_t *test_state, const char *tag_attribs) {
-    int rc = PLCTAG_STATUS_OK;
-
     /* create tag */
     test_state->tag = plc_tag_create_ex(tag_attribs, tag_callback, test_state, DATA_TIMEOUT);
     if(test_state->tag < 0) {
@@ -197,7 +196,6 @@ void stop_server(void) {
     /* wait for it to die */
     compat_sleep_ms(500, NULL);
 }
-
 
 void tag_callback(int32_t tag_id, int event, int status, void *data) {
     test_state_t *test_state = (test_state_t *)data;
@@ -294,7 +292,7 @@ void do_reconnect(int64_t current_time, test_state_t *test_state) {
 
 int calc_test_stats(test_state_t *test_state) {
     /* calculate the expected number of reads based on auto_sync_read_ms */
-    int expected_reads = TEST_DURATION_MS / AUTO_READ_POLL_MS;
+    int expected_reads = TEST_DURATION_MS / test_state->read_timeout_ms;
 
     /* print results */
     log("\nTest Results:\n");
@@ -303,17 +301,6 @@ int calc_test_stats(test_state_t *test_state) {
     log("Read errors: %d\n", test_state->read_error_count);
     log("Successful reads after reconnect: %d\n", test_state->read_success_after_reconnect);
     log("Time from reconnect to end: %" PRId64 " ms\n", test_state->end_time - test_state->reconnect_time);
-
-    /* manually attempt to trigger a read after the test to verify the connection works */
-    log("Attempting a final manual read to verify connection state...\n");
-    int manual_read_rc = plc_tag_read(test_state->tag, 0);
-    if(manual_read_rc == PLCTAG_STATUS_OK) {
-        log("Manual read succeeded. Tag value: %d\n", plc_tag_get_int32(test_state->tag, 0));
-    } else {
-        log("Manual read failed with status: %s\n", plc_tag_decode_error(manual_read_rc));
-    }
-
-    /* log the count of successful reads after reconnect */
     log("Final successful reads after reconnect: %d\n", test_state->read_success_after_reconnect);
     log("Errors during disconnection period: %d\n", test_state->errors_during_disconnect);
 
@@ -356,57 +343,60 @@ int calc_test_stats(test_state_t *test_state) {
 int run_auto_test(const char *ab_server_cmd) {
     int64_t current_time = 0;
     int64_t next_pct = 0;
-    test_state_t test_state = {0};
+    test_state_t auto_test_state = {0};
 
-    log("\nAuto tag test running for %dms...\n", TEST_DURATION_MS);
+    log("Auto tag test running for %dms...\n", TEST_DURATION_MS);
 
     /* initialize test state */
-    test_state.ab_server_cmd = ab_server_cmd;
-    test_state.start_time = compat_time_ms();
-    test_state.end_time = test_state.start_time + TEST_DURATION_MS;
-    test_state.disconnect_time = test_state.start_time + (TEST_DURATION_MS / 4); /* Disconnect after 25% of the test */
-    test_state.reconnect_time = 0;                                               /* Will be set when disconnect happens */
-    test_state.test_passed = 0;
-    test_state.reconnect_done = 0;
+    auto_test_state.ab_server_cmd = ab_server_cmd;
+    auto_test_state.start_time = compat_time_ms();
+    auto_test_state.end_time = auto_test_state.start_time + TEST_DURATION_MS;
+    auto_test_state.disconnect_time = auto_test_state.start_time + (TEST_DURATION_MS / 4); /* Disconnect after 25% of the test */
+    auto_test_state.read_timeout_ms = AUTO_READ_POLL_MS;
+    auto_test_state.reconnect_time = 0; /* Will be set when disconnect happens */
+    auto_test_state.test_passed = 0;
+    auto_test_state.reconnect_done = 0;
 
-    start_server(&test_state);
+    start_server(&auto_test_state);
 
     /* set up the tag and set the callback */
-    setup_tag(&test_state, AUTO_SYNC_TAG_ATTRIBS);
+    setup_tag(&auto_test_state, AUTO_SYNC_TAG_ATTRIBS);
 
-    while((current_time = compat_time_ms()) < test_state.end_time) {
-        int64_t complete_pct = (current_time - test_state.start_time) * 100 / TEST_DURATION_MS;
+    while((current_time = compat_time_ms()) < auto_test_state.end_time) {
+        int64_t complete_pct = (current_time - auto_test_state.start_time) * 100 / TEST_DURATION_MS;
 
         /* log stats every 5% */
         if(complete_pct >= next_pct) {
-            int tag_status = plc_tag_status(test_state.tag);
-            int64_t elapsed_ms = current_time - test_state.start_time;
+            int tag_status = plc_tag_status(auto_test_state.tag);
+            int64_t elapsed_ms = current_time - auto_test_state.start_time;
 
             next_pct = complete_pct + 5;
 
             log("\n[STATUS] Test progress: %" PRId64 "%% complete (elapsed: %" PRId64 " ms)\n", complete_pct, elapsed_ms);
             log("[STATUS] Tag status: %s\n", plc_tag_decode_error(tag_status));
-            log("[STATUS] Read stats: started=%d, completed=%d, timeouts=%d, errors=%d\n", test_state.read_start_count,
-                test_state.read_success_count, test_state.read_timeout_count, test_state.read_error_count);
+            log("[STATUS] Read stats: started=%d, completed=%d, timeouts=%d, errors=%d\n", auto_test_state.read_start_count,
+                auto_test_state.read_success_count, auto_test_state.read_timeout_count, auto_test_state.read_error_count);
 
             /* If we're past the reconnect time, print additional diagnostics */
-            if(test_state.reconnect_time > 0 && elapsed_ms > test_state.reconnect_time) {
+            if(auto_test_state.reconnect_time > 0 && elapsed_ms > auto_test_state.reconnect_time) {
                 log("[STATUS] Time since reconnect: %" PRId64 "ms, read completions after reconnect: %d\n",
-                    current_time - test_state.reconnect_time, test_state.read_success_after_reconnect);
+                    current_time - auto_test_state.reconnect_time, auto_test_state.read_success_after_reconnect);
             }
         }
 
         /* check if it's time to simulate a PLC disconnect */
-        if(test_state.disconnect_time > 0 && current_time >= test_state.disconnect_time && test_state.reconnect_time == 0) {
-            do_disconnect(current_time, &test_state);
+        if(auto_test_state.disconnect_time > 0 && current_time >= auto_test_state.disconnect_time
+           && auto_test_state.reconnect_time == 0) {
+            do_disconnect(current_time, &auto_test_state);
         }
 
         /* check if it's time to simulate a PLC reconnect - only do once */
-        if(test_state.reconnect_time > 0 && current_time >= test_state.reconnect_time && !test_state.reconnect_done) {
-            do_reconnect(current_time, &test_state);
+        if(auto_test_state.reconnect_time > 0 && current_time >= auto_test_state.reconnect_time
+           && !auto_test_state.reconnect_done) {
+            do_reconnect(current_time, &auto_test_state);
 
             /* there is a data race here but we do not need to be exact. */
-            test_state.reconnect_done = true;
+            auto_test_state.reconnect_done = true;
         }
 
         compat_sleep_ms(AUTO_READ_POLL_MS / 2, NULL);
@@ -414,78 +404,102 @@ int run_auto_test(const char *ab_server_cmd) {
 
     log("[STATUS] Test completed.\n");
 
-    plc_tag_destroy(test_state.tag);
+    plc_tag_destroy(auto_test_state.tag);
 
     stop_server();
 
-    return calc_test_stats(&test_state);
+    return calc_test_stats(&auto_test_state);
 }
 
 
 int run_manual_test(const char *ab_server_cmd) {
     int64_t current_time = 0;
+    int64_t wait_until_ms = 0;
     int64_t next_pct = 0;
-    test_state_t test_state = {0};
+    test_state_t manual_test_state = {0};
 
-    log("\n\nManual tag test running for %dms...\n", TEST_DURATION_MS);
+    log("Manual tag test running for %dms...\n", TEST_DURATION_MS);
 
     /* initialize test state */
-    test_state.ab_server_cmd = ab_server_cmd;
-    test_state.start_time = compat_time_ms();
-    test_state.end_time = test_state.start_time + TEST_DURATION_MS;
-    test_state.disconnect_time = test_state.start_time + (TEST_DURATION_MS / 4); /* Disconnect after 25% of the test */
-    test_state.reconnect_time = 0;                                               /* Will be set when disconnect happens */
-    test_state.test_passed = 0;
-    test_state.reconnect_done = 0;
+    manual_test_state.ab_server_cmd = ab_server_cmd;
+    manual_test_state.start_time = compat_time_ms();
+    manual_test_state.end_time = manual_test_state.start_time + TEST_DURATION_MS;
+    manual_test_state.disconnect_time =
+        manual_test_state.start_time + (TEST_DURATION_MS / 4); /* Disconnect after 25% of the test */
+    manual_test_state.read_timeout_ms = MANUAL_READ_TIMEOUT_MS;
+    manual_test_state.reconnect_time = 0; /* Will be set when disconnect happens */
+    manual_test_state.test_passed = 0;
+    manual_test_state.reconnect_done = 0;
 
-    start_server(&test_state);
+    start_server(&manual_test_state);
 
     /* set up the tag and set the callback */
-    setup_tag(&test_state, MANUAL_SYNC_TAG_ATTRIBS);
+    setup_tag(&manual_test_state, MANUAL_SYNC_TAG_ATTRIBS);
 
-    while((current_time = compat_time_ms()) < test_state.end_time) {
-        int64_t complete_pct = (current_time - test_state.start_time) * 100 / TEST_DURATION_MS;
+    while((current_time = compat_time_ms()) < manual_test_state.end_time) {
+        int64_t complete_pct = (current_time - manual_test_state.start_time) * 100 / TEST_DURATION_MS;
+
+        if(wait_until_ms != 0) {
+            wait_until_ms = wait_until_ms + MANUAL_READ_TIMEOUT_MS;
+        } else {
+            wait_until_ms = current_time + MANUAL_READ_TIMEOUT_MS;
+        }
 
         /* log stats every 5% */
         if(complete_pct >= next_pct) {
-            int tag_status = plc_tag_status(test_state.tag);
-            int64_t elapsed_ms = current_time - test_state.start_time;
+            int tag_status = plc_tag_status(manual_test_state.tag);
+            int64_t elapsed_ms = current_time - manual_test_state.start_time;
 
             next_pct = complete_pct + 5;
 
             log("\n[STATUS] Test progress: %" PRId64 "%% complete (elapsed: %" PRId64 " ms)\n", complete_pct, elapsed_ms);
             log("[STATUS] Tag status: %s\n", plc_tag_decode_error(tag_status));
-            log("[STATUS] Read stats: started=%d, completed=%d, timeouts=%d, errors=%d\n", test_state.read_start_count,
-                test_state.read_success_count, test_state.read_timeout_count, test_state.read_error_count);
+            log("[STATUS] Read stats: started=%d, completed=%d, timeouts=%d, errors=%d\n", manual_test_state.read_start_count,
+                manual_test_state.read_success_count, manual_test_state.read_timeout_count, manual_test_state.read_error_count);
 
             /* If we're past the reconnect time, print additional diagnostics */
-            if(test_state.reconnect_time > 0 && elapsed_ms > test_state.reconnect_time) {
+            if(manual_test_state.reconnect_time > 0 && elapsed_ms > manual_test_state.reconnect_time) {
                 log("[STATUS] Time since reconnect: %" PRId64 "ms, read completions after reconnect: %d\n",
-                    current_time - test_state.reconnect_time, test_state.read_success_after_reconnect);
+                    current_time - manual_test_state.reconnect_time, manual_test_state.read_success_after_reconnect);
             }
         }
 
         /* check if it's time to simulate a PLC disconnect */
-        if(test_state.disconnect_time > 0 && current_time >= test_state.disconnect_time && test_state.reconnect_time == 0) {
-            do_disconnect(current_time, &test_state);
+        if(manual_test_state.disconnect_time > 0 && current_time >= manual_test_state.disconnect_time
+           && manual_test_state.reconnect_time == 0) {
+            do_disconnect(current_time, &manual_test_state);
         }
 
         /* check if it's time to simulate a PLC reconnect - only do once */
-        if(test_state.reconnect_time > 0 && current_time >= test_state.reconnect_time && !test_state.reconnect_done) {
-            do_reconnect(current_time, &test_state);
+        if(manual_test_state.reconnect_time > 0 && current_time >= manual_test_state.reconnect_time
+           && !manual_test_state.reconnect_done) {
+            do_reconnect(current_time, &manual_test_state);
 
             /* there is a data race here but we do not need to be exact. */
-            test_state.reconnect_done = true;
+            manual_test_state.reconnect_done = true;
         }
 
-        plc_tag_read(test_state.tag, MANUAL_READ_TIMEOUT_MS);
+        plc_tag_read(manual_test_state.tag, MANUAL_READ_TIMEOUT_MS);
+
+        /* wait at least the timeout time */
+        wait_until_time_ms(wait_until_ms);
     }
 
     log("[STATUS] Test completed.\n");
 
-    plc_tag_destroy(test_state.tag);
+    plc_tag_destroy(manual_test_state.tag);
 
     stop_server();
 
-    return calc_test_stats(&test_state);
+    return calc_test_stats(&manual_test_state);
+}
+
+
+void wait_until_time_ms(int64_t time_ms) {
+    int64_t current_time = compat_time_ms();
+    int64_t remaining_time = time_ms - current_time;
+
+    if(remaining_time <= 0) { return; }
+
+    compat_sleep_ms((uint32_t)(uint64_t)remaining_time, NULL);
 }

--- a/src/libplctag/lib/lib.c
+++ b/src/libplctag/lib/lib.c
@@ -380,40 +380,8 @@ void plc_tag_generic_tickler(plc_tag_p tag) {
                     pdebug(DEBUG_DETAIL, "Scheduling next read at time %" PRId64 ".", tag->auto_sync_next_read);
                 } else {
                     pdebug(DEBUG_SPEW,
-                           "Unable to start read tag->read_in_flight=%d, tag->tag_is_dirty=%d, tag->write_in_flight=%d!",
+                           "Unable to start auto read tag->read_in_flight=%d, tag->tag_is_dirty=%d, tag->write_in_flight=%d!",
                            tag->read_in_flight, tag->tag_is_dirty, tag->write_in_flight);
-
-                    /* check for stalled reads that might be from a connection loss */
-                    if(tag->read_in_flight) {
-                        /* define a timeout for potentially stalled operations - use 3x the auto_sync interval as a reasonable
-                         * timeout */
-                        /* TODO - this should be a tag-specific value */
-                        int64_t read_timeout = tag->auto_sync_read_ms * 3;
-
-                        /* if we have a read in flight for longer than our timeout, assume it stalled due to connection issues */
-                        if((current_time - tag->auto_sync_next_read) > read_timeout) {
-                            pdebug(
-                                DEBUG_WARN,
-                                "Auto-sync read operation appears stalled (possibly due to connection loss). Resetting state to allow reconnection.");
-
-                            /* abort any outstanding transaction. */
-                            // if(tag->vtable && tag->vtable->abort) { tag->vtable->abort(tag); }
-
-                            /* reset the read operation flags */
-                            tag->read_in_flight = 0;
-                            tag->read_complete = 0;
-
-                            /* set status to an error to indicate connection problem */
-                            tag->status = PLCTAG_ERR_TIMEOUT;
-
-                            /* raise abort event to notify callbacks */
-                            tag_raise_event(tag, PLCTAG_EVENT_ABORTED, PLCTAG_ERR_TIMEOUT);
-
-                            /* reschedule for the next interval */
-                            tag->auto_sync_next_read = current_time + tag->auto_sync_read_ms;
-                            pdebug(DEBUG_DETAIL, "Rescheduling next read attempt at time %" PRId64 ".", tag->auto_sync_next_read);
-                        }
-                    }
                 }
             }
         }

--- a/src/libplctag/protocols/ab/session.c
+++ b/src/libplctag/protocols/ab/session.c
@@ -409,7 +409,7 @@ int add_session_unsafe(ab_session_p session) {
 
     if(!session) { return PLCTAG_ERR_NULL_PTR; }
 
-    vector_put(sessions, vector_length(sessions), session);
+    vector_set(sessions, vector_length(sessions), session);
 
     session->on_list = 1;
 
@@ -1150,7 +1150,7 @@ int session_add_request(ab_session_p session, ab_request_p req) {
         }
 
         /* insert into the requests vector */
-        vector_put(session->requests, vector_length(session->requests), req);
+        vector_set(session->requests, vector_length(session->requests), req);
     }
 
     /* wake up the session thread because we added something to process. */
@@ -1822,18 +1822,13 @@ int process_requests(ab_session_p session) {
             rc = PLCTAG_STATUS_OK;
         } while(0);
 
-        /* problem? clean up the pending requests and dump everything. */
+        /* problem? push the requests back on the queue. */
         if(rc != PLCTAG_STATUS_OK) {
-            for(int i = 0; i < num_bundled_requests; i++) {
-                if(bundled_requests[i]) {
-                    bundled_requests[i]->status = rc;
-                    bundled_requests[i]->request_size = 0;
-                    bundled_requests[i]->resp_received = 1;
+            pdebug(DEBUG_WARN, "Error sending or receiving requests!");
 
-                    pdebug(DEBUG_DETAIL, "rc_dec: Releasing request reference.");
-                    bundled_requests[i] = rc_dec(bundled_requests[i]);
-                }
-            }
+            pdebug(DEBUG_INFO, "Pushing %d requests back into the queue.", num_bundled_requests);
+
+            for(int i = num_bundled_requests - 1; i >= 0; i--) { vector_insert(session->requests, 0, bundled_requests[i]); }
         }
 
         /* tickle the main tickler thread to note that we have responses. */

--- a/src/tests/run_full_tests.sh
+++ b/src/tests/run_full_tests.sh
@@ -21,7 +21,7 @@ if [[ ! -d $TEST_DIR ]]; then
 fi
 
 # test for the executables.
-EXECUTABLES="ab_server list_tags_logix modbus_server string_non_standard_udt string_standard tag_rw2 test_auto_sync test_auto_sync_reconnect test_callback test_callback_ex test_callback_ex_logix test_callback_ex_modbus test_raw_cip test_reconnect test_shutdown test_special test_string test_tag_attributes test_tag_type_attribute thread_stress"
+EXECUTABLES="ab_server list_tags_logix modbus_server string_non_standard_udt string_standard tag_rw2 test_auto_sync test_reconnect_after_outage test_callback test_callback_ex test_callback_ex_logix test_callback_ex_modbus test_raw_cip test_reconnect test_shutdown test_special test_string test_tag_attributes test_tag_type_attribute thread_stress"
 # echo -n "  Checking for executables..."
 for EXECUTABLE in $EXECUTABLES
 do
@@ -269,6 +269,17 @@ fi
 # echo "  Killing AB emulator."
 killall -TERM ab_server > /dev/null 2>&1
 
+let TEST++
+echo -n "Test $TEST: Test reconnect after PLC outage... "
+$VALGRIND$TEST_DIR/test_reconnect_after_outage "${TEST_DIR}/ab_server" > "${TEST}_reconnect_after_outage.log" 2>&1
+if [ $? != 0 ]; then
+    echo "FAILURE"
+    let FAILURES++
+else
+    echo "OK"
+    let SUCCESSES++
+fi
+
 
 # echo -n "  Starting AB emulator for functional/slow ControlLogix tests... "
 $VALGRIND$TEST_DIR/ab_server --plc=ControlLogix --path=1,0 "--tag=TestBigArray:DINT[2000]" "--tag=Test_Array_1:DINT[1000]" "--tag=Test_Array_2x3:DINT[2,3]" "--tag=Test_Array_2x3x4:DINT[2,3,4]" --delay=20  > logix_slow_emulator.log 2>&1 &
@@ -445,7 +456,7 @@ sleep 2
 # Run auto_sync_reconnect test last since it manages its own ab_server
 let TEST++
 echo -n "Test $TEST: auto sync reconnect... "
-$VALGRIND$TEST_DIR/test_auto_sync_reconnect "${TEST_DIR}/ab_server" > "${TEST}_auto_sync_reconnect_test.log" 2>&1
+$VALGRIND$TEST_DIR/test_reconnect_after_outage "${TEST_DIR}/ab_server" > "${TEST}_auto_sync_reconnect_test.log" 2>&1
 if [ $? != 0 ]; then
     echo "FAILURE"
     let FAILURES++

--- a/src/tests/run_simulator_tests.sh
+++ b/src/tests/run_simulator_tests.sh
@@ -21,7 +21,7 @@ if [[ ! -d $TEST_DIR ]]; then
 fi
 
 # test for the executables.
-EXECUTABLES="ab_server list_tags_logix string_non_standard_udt string_standard tag_rw2 test_auto_sync test_callback test_callback_ex test_callback_ex_logix test_callback_ex_modbus test_raw_cip test_reconnect test_shutdown test_special test_string test_tag_attributes test_tag_type_attribute thread_stress"
+EXECUTABLES="ab_server list_tags_logix string_non_standard_udt string_standard tag_rw2 test_auto_sync test_callback test_callback_ex test_callback_ex_logix test_callback_ex_modbus test_raw_cip test_reconnect_after_outage test_shutdown test_special test_string test_tag_attributes test_tag_type_attribute thread_stress"
 # echo -n "  Checking for executables..."
 for EXECUTABLE in $EXECUTABLES
 do
@@ -117,6 +117,17 @@ fi
 
 # echo "  Killing AB emulator."
 killall -TERM ab_server > /dev/null 2>&1
+
+let TEST++
+echo -n "Test $TEST: Test reconnect after PLC outage... "
+$VALGRIND$TEST_DIR/test_reconnect_after_outage "${TEST_DIR}/ab_server" > "${TEST}_reconnect_after_outage.log" 2>&1
+if [ $? != 0 ]; then
+    echo "FAILURE"
+    let FAILURES++
+else
+    echo "OK"
+    let SUCCESSES++
+fi
 
 
 echo "Starting AB emulator for functional/slow ControlLogix tests."

--- a/src/utils/vector.c
+++ b/src/utils/vector.c
@@ -100,8 +100,54 @@ int vector_length(vector_p vec) {
     return vec->len;
 }
 
+int vector_insert(vector_p vec, int index, void *data) {
+    int rc = PLCTAG_STATUS_OK;
 
-int vector_put(vector_p vec, int index, void *data) {
+    pdebug(DEBUG_SPEW, "Starting");
+
+    do {
+        if(!vec) {
+            pdebug(DEBUG_WARN, "Null pointer or invalid pointer to vector passed!");
+            rc = PLCTAG_ERR_NULL_PTR;
+            break;
+        }
+
+        if(index < 0) {
+            pdebug(DEBUG_WARN, "Index is negative!");
+            rc = PLCTAG_ERR_OUT_OF_BOUNDS;
+            break;
+        }
+
+        /* inserting outside the vector works */
+        if(index >= vec->len) {
+            rc = vector_set(vec, index, data);
+            break;
+        }
+
+        /* make sure we have room */
+        rc = ensure_capacity(vec, vec->len + 1);
+        if(rc != PLCTAG_STATUS_OK) {
+            pdebug(DEBUG_WARN, "Unable to ensure capacity!");
+            break;
+        }
+
+        /* move everything up one slot */
+        mem_move(&vec->data[index + 1], &vec->data[index], (int)((sizeof(void *) * (size_t)(vec->len - index))));
+
+        /* put in the new value */
+        vec->data[index] = data;
+
+        /* adjust the length */
+        vec->len++;
+    } while(0);
+
+    pdebug(DEBUG_SPEW, "Done");
+
+    return rc;
+}
+
+
+int vector_set(vector_p vec, int index, void *data) {
     int rc = PLCTAG_STATUS_OK;
 
     pdebug(DEBUG_SPEW, "Starting");

--- a/src/utils/vector.h
+++ b/src/utils/vector.h
@@ -38,8 +38,8 @@ typedef struct vector_t *vector_p;
 
 extern vector_p vector_create(int capacity, int max_inc);
 extern int vector_length(vector_p vec);
-extern int vector_put(vector_p vec, int index, void * ref);
+extern int vector_insert(vector_p vec, int index, void *data);
+extern int vector_set(vector_p vec, int index, void *ref);
 extern void *vector_get(vector_p vec, int index);
-extern int vector_on_each(vector_p vec, int (*callback_func)(vector_p vec, int index, void **data, int arg_count, void **args), int num_args, ...);
 extern void *vector_remove(vector_p vec, int index);
 extern int vector_destroy(vector_p vec);


### PR DESCRIPTION
This reverts the original auto sync changes.  The code in session.c and conn.c have changed to requeue any requests in flight if there is a problem sending a request or receiving a response from the PLC.