### PR TITLE
Simultaneous Read/Write on a Tag using the ab_server issue

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -275,17 +275,6 @@ jobs:
         echo "shut down server."
         killall ab_server -INT &> /dev/null
 
-    - name: Test Array Notation Read/Write
-      run: |
-        cd ${{ env.DIST }}
-        echo "start up simulator..."
-        ${{ env.DIST }}/ab_server --plc=ControlLogix --path=1,0 --tag=TestBigArray:DINT[5] &
-        sleep 2
-        echo "test array notation read/write"
-        ${{ env.DIST }}/test_array_notation 127.0.0.1 1,0 TestBigArray 5 2000
-        echo "shut down server."
-        killall ab_server -INT &> /dev/null
-
     - name: Upload ZIP artifact
       uses: actions/upload-artifact@v4
       with:
@@ -397,17 +386,6 @@ jobs:
         sleep 2
         echo "test getting a large tag."
         ${{ env.DIST }}/tag_rw2 --type=sint32 '--tag=protocol=ab-eip&gateway=127.0.0.1&path=1,0&plc=ControlLogix&elem_count=2000&name=TestBigArray'
-        echo "shut down server."
-        killall ab_server -INT &> /dev/null
-
-    - name: Test Array Notation Read/Write
-      run: |
-        cd ${{ env.DIST }}
-        echo "start up simulator..."
-        ${{ env.DIST }}/ab_server --plc=ControlLogix --path=1,0 --tag=TestBigArray:DINT[5] &
-        sleep 2
-        echo "test array notation read/write"
-        ${{ env.DIST }}/test_array_notation 127.0.0.1 1,0 TestBigArray 5 2000
         echo "shut down server."
         killall ab_server -INT &> /dev/null
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -130,6 +130,12 @@ jobs:
         echo "shut down server."
         killall ab_server -INT &> /dev/null
 
+    - name: Test Simultaneaous Read/Write On Tag
+      run: |
+        cd ${{ env.DIST }}
+        echo "test simultaneaous read/write on a single tag"
+        .\test_simultaneous_rw_ab_server
+
     - name: Test Reconnect After Outage
       run: |
         cd ${{ env.DIST }}
@@ -275,6 +281,12 @@ jobs:
         echo "shut down server."
         killall ab_server -INT &> /dev/null
 
+    - name: Test Simultaneaous Read/Write On Tag
+      run: |
+        cd ${{ env.DIST }}
+        echo "test simultaneaous read/write on a single tag"
+        .\test_simultaneous_rw_ab_server
+
     - name: Upload ZIP artifact
       uses: actions/upload-artifact@v4
       with:
@@ -399,6 +411,12 @@ jobs:
         ${{ env.DIST }}/test_array_notation 127.0.0.1 1,0 TestBigArray 5 2000
         echo "shut down server."
         killall ab_server -INT &> /dev/null
+
+    - name: Test Simultaneaous Read/Write On Tag
+      run: |
+        cd ${{ env.DIST }}
+        echo "test simultaneaous read/write on a single tag"
+        .\test_simultaneous_rw_ab_server
 
     - name: Upload ZIP artifact
       uses: actions/upload-artifact@v4
@@ -577,6 +595,15 @@ jobs:
         exit /b %test_result%
       shell: cmd
 
+    - name: Test Simultaneaous Read/Write On Tag
+      run: |
+        cd ${{ env.DIST }}
+        echo "test simultaneaous read/write on a single tag"
+        .\test_simultaneous_rw_ab_server.exe
+        set test_result=%errorlevel%
+        exit /b %test_result%
+      shell: cmd
+
     - name: Test Reconnect After Outage
       run: |
         cd ${{ env.DIST }}
@@ -721,6 +748,15 @@ jobs:
         exit /b %test_result%
       shell: cmd
 
+    - name: Test Simultaneaous Read/Write On Tag
+      run: |
+        cd ${{ env.DIST }}
+        echo "test simultaneaous read/write on a single tag"
+        .\test_simultaneous_rw_ab_server.exe
+        set test_result=%errorlevel%
+        exit /b %test_result%
+      shell: cmd
+
   windows_x86_MSVC:
 
     runs-on: windows-latest
@@ -853,6 +889,15 @@ jobs:
         set test_result=%errorlevel%
         echo "shut down server."
         taskkill /F /IM ab_server.exe
+        exit /b %test_result%
+      shell: cmd
+
+    - name: Test Simultaneaous Read/Write On Tag
+      run: |
+        cd ${{ env.DIST }}
+        echo "test simultaneaous read/write on a single tag"
+        .\test_simultaneous_rw_ab_server.exe
+        set test_result=%errorlevel%
         exit /b %test_result%
       shell: cmd
 
@@ -990,6 +1035,15 @@ jobs:
         set test_result=%errorlevel%
         echo "shut down server."
         taskkill /F /IM ab_server.exe
+        exit /b %test_result%
+      shell: cmd
+
+    - name: Test Simultaneaous Read/Write On Tag
+      run: |
+        cd ${{ env.DIST }}
+        echo "test simultaneaous read/write on a single tag"
+        .\test_simultaneous_rw_ab_server.exe
+        set test_result=%errorlevel%
         exit /b %test_result%
       shell: cmd
 

--- a/src/examples/CMakeLists.txt
+++ b/src/examples/CMakeLists.txt
@@ -49,6 +49,7 @@ set(EXAMPLE_EXECUTABLES
   test_raw_cip
   test_reconnect
   test_shutdown
+  test_simultaneous_rw_ab_server
   test_special
   test_string
   test_tag_attributes

--- a/src/examples/test_simultaneous_rw_ab_server.c
+++ b/src/examples/test_simultaneous_rw_ab_server.c
@@ -1,0 +1,141 @@
+#include "compat_utils.h"
+#include <cstdio>
+#include <libplctag/lib/libplctag.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <stdint.h>
+#include <winreg.h>
+
+#ifdef _WIN32
+  #define SERVER_CMD_START "start /B ab_server --plc=ControlLogix --path=1,0 --tag=TestTag:DINT[1]"
+  #define SERVER_CMD_STOP "taskkill /IM ab_server.exe /F"
+#else
+  #define SERVER_CMD_START "./ab_server --plc=ControlLogix --path=1,0 --tag=TestTag:DINT[1] &"
+  #define SERVER_CMD_STOP "pkill -f ab_server"
+#endif
+
+#define REQUIRED_VERSION 2, 6, 4
+#define TAG_ATTRIBS "protocol=ab-eip&gateway=127.0.0.1&path=1,0&cpu=ControlLogix&elem_type=DINT&elem_count=1&name=TestTag[0]&debug=2"
+#define TIMEOUT_MS 5000
+#define RUN_TIME_MS 5000
+#define SLEEP_MS 100
+#define EXPECTED_VALUE 42
+
+static volatile int running = 1;
+static volatile int read_passed = 1;
+static volatile int write_passed = 1;
+
+void* reader_thread(void* arg) {
+    int32_t tag = plc_tag_create(TAG_ATTRIBS, TIMEOUT_MS);
+    if (tag < 0) {
+        fprintf(stderr, "[ERROR] Could not create tag for reading: %s\n", plc_tag_decode_error(tag));
+        read_passed = 0;
+        return NULL;
+    }
+
+    while (running) {
+        int rc = plc_tag_read(tag, TIMEOUT_MS);
+        if (rc == PLCTAG_STATUS_OK) {
+            int val = plc_tag_get_int32(tag, 0);
+            if (val == EXPECTED_VALUE) {
+                fprintf(stdout, "[INFO ] Value is %d.\n", EXPECTED_VALUE);
+            } else {
+                // Failed
+                fprintf(stderr, "[ERROR] Unexpected value: %d\n", val);
+                read_passed = 0;
+            }
+        } else {
+            fprintf(stderr, "[ERROR] Read failed: %s\n", plc_tag_decode_error(rc));
+            read_passed = 0;
+        }
+        compat_sleep_ms(SLEEP_MS, NULL);
+    }
+    
+    plc_tag_destroy(tag);
+    return NULL;
+}
+
+void* writer_thread(void* arg) {
+    int32_t tag = plc_tag_create(TAG_ATTRIBS, TIMEOUT_MS);
+    if (tag < 0) {
+        fprintf(stderr, "[ERROR] Could not create tag for writing: %s\n", plc_tag_decode_error(tag));
+        write_passed = 0;
+        return NULL;
+    }
+
+    plc_tag_set_int32(tag, 0, EXPECTED_VALUE);
+    int rc = plc_tag_write(tag, TIMEOUT_MS);
+    if (rc == PLCTAG_STATUS_OK) {
+        fprintf(stdout, "[WRITE] Value: %d\n", EXPECTED_VALUE);
+    } else {
+        fprintf(stderr, "[ERROR] Write failed: %s\n", plc_tag_decode_error(rc));
+        write_passed = 0;
+    }
+
+    plc_tag_destroy(tag);
+
+    return NULL;
+}
+
+void start_server() {
+    fprintf(stdout, "[INFO ] Starting ab_server...\n");
+    int rc = system(SERVER_CMD_START);
+    if (rc != 0) {
+        fprintf(stderr, "[ERROR] Failed to start ab_server\n");
+        exit(1);
+    }
+    compat_sleep_ms(1000, NULL); // wait for server to initialize
+}
+
+void stop_server() {
+    fprintf(stdout, "[INFO ] Stopping ab_server...\n");
+    system(SERVER_CMD_STOP);
+    compat_sleep_ms(500, NULL);
+}
+
+int main(void) {
+    if (plc_tag_check_lib_version(REQUIRED_VERSION) != PLCTAG_STATUS_OK) {
+        fprintf(stderr, "ERROR: libplctag version not compatible\n");
+        return 1;
+    }
+
+    start_server();
+
+    int32_t tag = plc_tag_create(TAG_ATTRIBS, TIMEOUT_MS);
+    if (tag < 0) {
+        fprintf(stderr, "ERROR: Could not create tag: %s\n", plc_tag_decode_error(tag));
+        stop_server();
+        return 1;
+    }
+
+    compat_thread_t reader, writer;
+    compat_thread_create(&writer, writer_thread, (void*)(intptr_t)tag);
+    compat_thread_create(&reader, reader_thread, (void*)(intptr_t)tag);
+
+    compat_sleep_ms(RUN_TIME_MS, NULL);
+    running = 0;
+
+    compat_thread_join(reader, NULL);
+    compat_thread_join(writer, NULL);
+
+    plc_tag_destroy(tag);
+    stop_server();
+
+    fprintf(stdout, "[DONE ] Test completed.\n");
+
+    if (!read_passed) {
+        fprintf(stderr, "[FAIL ] Read operations failed.\n");
+        return 1;
+    } else {
+        fprintf(stdout, "[PASS ] Read operations succeeded.\n");
+    }
+
+    if (!write_passed) {
+        fprintf(stderr, "[FAIL ] Write operation failed.\n");
+        return 1;
+    } else {
+        fprintf(stdout, "[PASS ] Write operation succeeded.\n");
+    }
+    
+    return 0;
+}


### PR DESCRIPTION
This PR introduces a test that reproduces an issue occurring during simultaneous read and write operations on the same tag across two concurrent threads when using ab_server.

The test is expected to fail currently, as no fix has been applied yet. Its purpose is to document and reliably reproduce the issue, so that a proper solution can be developed and verified against it.

**Details**:

- Two threads access the same tag concurrently: one performs writes while the other performs reads.
- This setup highlights potential race conditions or data consistency problems under concurrent access.

Please note that this is not a fix — only a failing test to assist in diagnosing and resolving the problem.