### PR TITLE
v2.6.11 - More fixes for Micrologix/SLC bit writes, fix issue #572

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -539,7 +539,7 @@ jobs:
 
   windows_x64_MSVC:
 
-    runs-on: windows-latest
+    runs-on: windows-2022
 
     env:
       VERSION: "2.6.11"
@@ -713,7 +713,7 @@ jobs:
 
   windows_x64_MinGW:
 
-    runs-on: windows-latest
+    runs-on: windows-2022
 
     env:
       VERSION: "2.6.11"
@@ -858,7 +858,7 @@ jobs:
 
   windows_x86_MSVC:
 
-    runs-on: windows-latest
+    runs-on: windows-2022
 
     env:
       VERSION: "2.6.11"
@@ -1031,7 +1031,7 @@ jobs:
 
   windows_x86_MinGW:
 
-    runs-on: windows-latest
+    runs-on: windows-2022
 
     env:
       VERSION: "2.6.11"
@@ -1175,7 +1175,7 @@ jobs:
       shell: cmd
 
   windows_cross_build_ARM64_MSVC:
-    runs-on: windows-latest
+    runs-on: windows-2022
 
     env:
       VERSION: "2.6.11"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,8 +12,8 @@ jobs:
     runs-on: ubuntu-22.04
 
     env:
-      VERSION: "2.6.10"
-      ARTIFACT: "libplctag_2.6.10_ubuntu_x64"
+      VERSION: "2.6.11"
+      ARTIFACT: "libplctag_2.6.11_ubuntu_x64"
       BUILD: "${{ github.workspace }}/build"
       DIST: "${{ github.workspace }}/build/bin_dist"
       BRANCH: ${{ github.head_ref || github.ref_name }}
@@ -179,8 +179,8 @@ jobs:
     runs-on: ubuntu-22.04
 
     env:
-      VERSION: "2.6.10"
-      ARTIFACT: "libplctag_2.6.10_ubuntu_x86"
+      VERSION: "2.6.11"
+      ARTIFACT: "libplctag_2.6.11_ubuntu_x86"
       BUILD: "${{ github.workspace }}/build"
       DIST: "${{ github.workspace }}/build/bin_dist"
       BRANCH: ${{ github.head_ref || github.ref_name }}
@@ -336,8 +336,8 @@ jobs:
     runs-on: macos-latest
 
     env:
-      VERSION: "2.6.10"
-      ARTIFACT: "libplctag_2.6.10_macos_x64"
+      VERSION: "2.6.11"
+      ARTIFACT: "libplctag_2.6.11_macos_x64"
       BUILD: "${{ github.workspace }}/build"
       DIST: "${{ github.workspace }}/build/bin_dist"
       BRANCH: ${{ github.head_ref || github.ref_name }}
@@ -490,8 +490,8 @@ jobs:
     runs-on: macos-latest
 
     env:
-      VERSION: "2.6.10"
-      ARTIFACT: "libplctag_2.6.10_macos_aarch64"
+      VERSION: "2.6.11"
+      ARTIFACT: "libplctag_2.6.11_macos_aarch64"
       BUILD: "${{ github.workspace }}/build"
       DIST: "${{ github.workspace }}/build/bin_dist"
       BRANCH: ${{ github.head_ref || github.ref_name }}
@@ -542,8 +542,8 @@ jobs:
     runs-on: windows-latest
 
     env:
-      VERSION: "2.6.10"
-      ARTIFACT: "libplctag_2.6.10_windows_x64"
+      VERSION: "2.6.11"
+      ARTIFACT: "libplctag_2.6.11_windows_x64"
       BUILD: "${{ github.workspace }}\\build"
       DIST: "${{ github.workspace }}\\build\\bin_dist"
       BRANCH: ${{ github.head_ref || github.ref_name }}
@@ -716,8 +716,8 @@ jobs:
     runs-on: windows-latest
 
     env:
-      VERSION: "2.6.10"
-      ARTIFACT: "libplctag_2.6.10_windows_x64_MinGW"
+      VERSION: "2.6.11"
+      ARTIFACT: "libplctag_2.6.11_windows_x64_MinGW"
       BUILD: "${{ github.workspace }}\\build"
       DIST: "${{ github.workspace }}\\build\\bin_dist"
       BRANCH: ${{ github.head_ref || github.ref_name }}
@@ -861,8 +861,8 @@ jobs:
     runs-on: windows-latest
 
     env:
-      VERSION: "2.6.10"
-      ARTIFACT: "libplctag_2.6.10_windows_x86"
+      VERSION: "2.6.11"
+      ARTIFACT: "libplctag_2.6.11_windows_x86"
       BUILD: "${{ github.workspace }}\\build"
       DIST: "${{ github.workspace }}\\build\\bin_dist"
       BRANCH: ${{ github.head_ref || github.ref_name }}
@@ -1034,8 +1034,8 @@ jobs:
     runs-on: windows-latest
 
     env:
-      VERSION: "2.6.10"
-      ARTIFACT: "libplctag_2.6.10_windows_x86_MinGW"
+      VERSION: "2.6.11"
+      ARTIFACT: "libplctag_2.6.11_windows_x86_MinGW"
       BUILD: "${{ github.workspace }}\\build"
       DIST: "${{ github.workspace }}\\build\\bin_dist"
       BRANCH: ${{ github.head_ref || github.ref_name }}
@@ -1178,8 +1178,8 @@ jobs:
     runs-on: windows-latest
 
     env:
-      VERSION: "2.6.10"
-      ARTIFACT: "libplctag_2.6.10_windows_arm64"
+      VERSION: "2.6.11"
+      ARTIFACT: "libplctag_2.6.11_windows_arm64"
       BUILD: "${{ github.workspace }}\\build"
       DIST: "${{ github.workspace }}\\build\\bin_dist"
       BRANCH: ${{ github.head_ref || github.ref_name }}
@@ -1254,8 +1254,8 @@ jobs:
             target_arch: arm64
 
     env:
-      VERSION: "2.6.10"
-      ARTIFACT: "libplctag_2.6.10_ubuntu_${{ matrix.artifact_suffix }}"
+      VERSION: "2.6.11"
+      ARTIFACT: "libplctag_2.6.11_ubuntu_${{ matrix.artifact_suffix }}"
       BUILD: "${{ github.workspace }}/build"
       DIST: "${{ github.workspace }}/build/bin_dist"
       BRANCH: ${{ github.head_ref || github.ref_name }}
@@ -1472,7 +1472,7 @@ jobs:
     if: (github.base_ref == 'release' && github.event_name == 'pull_request' && github.event.action == 'closed' && github.event.pull_request.merged == true) || (github.event_name == 'push' && github.ref == 'refs/heads/release')
 
     env:
-      VERSION: "2.6.10"
+      VERSION: "2.6.11"
 
     steps:
     - name: Checkout repository
@@ -1529,13 +1529,13 @@ jobs:
       run: |
         git config user.name "github-actions[bot]"
         git config user.email "github-actions[bot]@users.noreply.github.com"
-        git tag -a "v2.6.10" -m "Release v2.6.10"
-        git push origin "v2.6.10"
+        git tag -a "v2.6.11" -m "Release v2.6.11"
+        git push origin "v2.6.11"
 
     - name: Create Release
       uses: softprops/action-gh-release@v2
       with:
-        tag_name: "v2.6.10"
+        tag_name: "v2.6.11"
         name: ${{ steps.get_pr_details.outputs.pr_title }}
         body: ${{ steps.get_pr_details.outputs.pr_body }}
         files: ./release_artifacts/**/*.zip

--- a/.github/workflows/ci.yml.in
+++ b/.github/workflows/ci.yml.in
@@ -539,7 +539,7 @@ jobs:
 
   windows_x64_MSVC:
 
-    runs-on: windows-latest
+    runs-on: windows-2022
 
     env:
       VERSION: "@VERSION@"
@@ -713,7 +713,7 @@ jobs:
 
   windows_x64_MinGW:
 
-    runs-on: windows-latest
+    runs-on: windows-2022
 
     env:
       VERSION: "@VERSION@"
@@ -858,7 +858,7 @@ jobs:
 
   windows_x86_MSVC:
 
-    runs-on: windows-latest
+    runs-on: windows-2022
 
     env:
       VERSION: "@VERSION@"
@@ -1031,7 +1031,7 @@ jobs:
 
   windows_x86_MinGW:
 
-    runs-on: windows-latest
+    runs-on: windows-2022
 
     env:
       VERSION: "@VERSION@"
@@ -1175,7 +1175,7 @@ jobs:
       shell: cmd
 
   windows_cross_build_ARM64_MSVC:
-    runs-on: windows-latest
+    runs-on: windows-2022
 
     env:
       VERSION: "@VERSION@"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -59,7 +59,7 @@ set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin_dist)
 # the project version
 set (libplctag_VERSION_MAJOR 2)
 set (libplctag_VERSION_MINOR 6)
-set (libplctag_VERSION_PATCH 10)
+set (libplctag_VERSION_PATCH 11)
 set (VERSION "${libplctag_VERSION_MAJOR}.${libplctag_VERSION_MINOR}.${libplctag_VERSION_PATCH}")
 
 set (LIB_NAME_SUFFIX "${libplctag_VERSION_MAJOR}.${libplctag_VERSION_MINOR}.${libplctag_VERSION_PATCH}")

--- a/src/libplctag/lib/version.h
+++ b/src/libplctag/lib/version.h
@@ -42,10 +42,10 @@
  * checking them against a dynamically linked library.
  */
 
-#define LIB_VER_STRING "2.6.10"
+#define LIB_VER_STRING "2.6.11"
 #define LIB_VER_MAJOR (2)
 #define LIB_VER_MINOR (6)
-#define LIB_VER_PATCH (10)
+#define LIB_VER_PATCH (11)
 
 extern const char *VERSION;
 extern const uint64_t version_major;

--- a/src/libplctag/protocols/ab/defs.h
+++ b/src/libplctag/protocols/ab/defs.h
@@ -103,7 +103,7 @@
 #define AB_EIP_PCCCLGX_TYPED_WRITE_FUNC ((uint8_t)0x67)
 #define AB_EIP_SLC_RANGE_READ_FUNC ((uint8_t)0xA2)
 #define AB_EIP_SLC_RANGE_WRITE_FUNC ((uint8_t)0xAA)
-#define AB_EIP_SLC_RANGE_BIT_WRITE_FUNC ((uint8_t)0xAB) /* SLC/MicroLogix bit write command */
+#define AB_EIP_SLC_RANGE_WRITE_MASK_FUNC ((uint8_t)0xAB)
 
 
 #define AB_PCCC_DATA_BIT 1

--- a/src/libplctag/protocols/ab/eip_plc5_dhp.c
+++ b/src/libplctag/protocols/ab/eip_plc5_dhp.c
@@ -31,35 +31,20 @@
  *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
  ***************************************************************************/
 
-
-#include <libplctag/lib/libplctag.h>
-#include <libplctag/protocols/ab/ab_common.h>
-#include <libplctag/protocols/ab/defs.h>
-#include <libplctag/protocols/ab/eip_plc5_dhp.h>
-#include <libplctag/protocols/ab/pccc.h>
-#include <libplctag/protocols/ab/session.h>
 #include <libplctag/protocols/ab/tag.h>
-#include <utils/debug.h>
 
+struct tag_vtable_t eip_plc5_dhp_vtable = {
+    .abort = (tag_vtable_func)ab_tag_abort_request, /* shared */
+    .read = (tag_vtable_func)pccc_dhp_tag_read_start,
+    .status = (tag_vtable_func)pccc_dhp_tag_status,
+    .tickler = (tag_vtable_func)pccc_dhp_tag_tickler,
+    .write = (tag_vtable_func)pccc_dhp_tag_write_start,
+    .wake_plc = (tag_vtable_func)NULL, /* wake_plc */
 
+    /* data accessors */
+    .get_int_attrib = ab_get_int_attrib,
+    .set_int_attrib = ab_set_int_attrib,
 
-static int tag_read_start(ab_tag_p tag);
-static int tag_write_start(ab_tag_p tag);
+    .get_byte_array_attrib = ab_get_byte_array_attrib
+};
 
-struct tag_vtable_t eip_plc5_dhp_vtable = {(tag_vtable_func)ab_tag_abort_request, /* shared */
-                                           (tag_vtable_func)tag_read_start, (tag_vtable_func)pccc_dhp_tag_status,
-                                           (tag_vtable_func)pccc_dhp_tag_tickler, (tag_vtable_func)tag_write_start,
-                                           (tag_vtable_func)NULL, /* wake_plc */
-
-                                           /* data accessors */
-                                           ab_get_int_attrib, ab_set_int_attrib,
-
-                                           ab_get_byte_array_attrib};
-
-int tag_read_start(ab_tag_p tag) {
-    return pccc_dhp_tag_read_start(tag, AB_EIP_PLC5_RANGE_READ_FUNC);
-}
-
-int tag_write_start(ab_tag_p tag) {
-    return pccc_dhp_tag_write_start(tag, AB_EIP_PLC5_RANGE_WRITE_FUNC);
-}

--- a/src/libplctag/protocols/ab/eip_plc5_pccc.c
+++ b/src/libplctag/protocols/ab/eip_plc5_pccc.c
@@ -31,31 +31,22 @@
  *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
  ***************************************************************************/
 
-#include <inttypes.h>
-#include <libplctag/lib/libplctag.h>
-#include <libplctag/protocols/ab/ab_common.h>
-#include <libplctag/protocols/ab/defs.h>
-#include <libplctag/protocols/ab/eip_plc5_pccc.h>
-#include <libplctag/protocols/ab/error_codes.h>
-#include <libplctag/protocols/ab/pccc.h>
-#include <libplctag/protocols/ab/session.h>
 #include <libplctag/protocols/ab/tag.h>
-#include <stdint.h>
-#include <utils/debug.h>
 
 
-/* PCCC */
-static int tag_read_start(ab_tag_p tag);
-static int tag_write_start(ab_tag_p tag);
+struct tag_vtable_t plc5_vtable = {
+    .abort = (tag_vtable_func)ab_tag_abort_request, /* shared */
+    .read = (tag_vtable_func)pccc_tag_read_start,
+    .status = (tag_vtable_func)pccc_tag_status,
+    .tickler = (tag_vtable_func)pccc_tag_tickler,
+    .write = (tag_vtable_func)pccc_tag_write_start,
+    .wake_plc = (tag_vtable_func)NULL, /* wake_plc */
 
-struct tag_vtable_t plc5_vtable = {(tag_vtable_func)ab_tag_abort_request, /* shared */
-                                   (tag_vtable_func)tag_read_start, (tag_vtable_func)pccc_tag_status, (tag_vtable_func)pccc_tag_tickler,
-                                   (tag_vtable_func)tag_write_start, (tag_vtable_func)NULL, /* wake_plc */
-
-                                   /* data accessors */
-                                   ab_get_int_attrib, ab_set_int_attrib,
-
-                                   ab_get_byte_array_attrib};
+    /* data accessors */
+    .get_int_attrib = ab_get_int_attrib,
+    .set_int_attrib = ab_set_int_attrib,
+    .get_byte_array_attrib = ab_get_byte_array_attrib
+};
 
 
 /* default string types used for PLC-5 PLCs. */
@@ -79,11 +70,3 @@ tag_byte_order_t plc5_tag_byte_order = {.is_allocated = 0,
                                         .str_total_length = 84,
                                         .str_pad_bytes = 0};
 
-
-int tag_read_start(ab_tag_p tag) {
-    return pccc_tag_read_start((ab_tag_p)tag, AB_EIP_PLC5_RANGE_READ_FUNC);
-}
-
-int tag_write_start(ab_tag_p tag) {
-    return pccc_tag_write_start((ab_tag_p)tag, AB_EIP_PLC5_RANGE_WRITE_FUNC);
-}

--- a/src/libplctag/protocols/ab/eip_slc_dhp.c
+++ b/src/libplctag/protocols/ab/eip_slc_dhp.c
@@ -32,33 +32,19 @@
  ***************************************************************************/
 
 
-#include <libplctag/lib/libplctag.h>
-#include <libplctag/protocols/ab/ab_common.h>
-#include <libplctag/protocols/ab/defs.h>
-#include <libplctag/protocols/ab/eip_slc_dhp.h>
-#include <libplctag/protocols/ab/pccc.h>
-#include <libplctag/protocols/ab/session.h>
 #include <libplctag/protocols/ab/tag.h>
-#include <utils/debug.h>
 
+struct tag_vtable_t eip_slc_dhp_vtable = {
+    .abort = (tag_vtable_func)ab_tag_abort_request, /* shared */
+    .read = (tag_vtable_func)pccc_dhp_tag_read_start,
+    .status = (tag_vtable_func)pccc_dhp_tag_status,
+    .tickler = (tag_vtable_func)pccc_dhp_tag_tickler,
+    .write = (tag_vtable_func)pccc_dhp_tag_write_start,
+    .wake_plc = (tag_vtable_func)NULL, /* wake_plc */
 
-static int tag_read_start(ab_tag_p tag);
-static int tag_write_start(ab_tag_p tag);
+    /* data accessors */
+    .get_int_attrib = ab_get_int_attrib,
+    .set_int_attrib = ab_set_int_attrib,
+    .get_byte_array_attrib = ab_get_byte_array_attrib
+};
 
-struct tag_vtable_t eip_slc_dhp_vtable = {(tag_vtable_func)ab_tag_abort_request, /* shared */
-                                   (tag_vtable_func)tag_read_start, (tag_vtable_func)pccc_dhp_tag_status, (tag_vtable_func)pccc_dhp_tag_tickler,
-                                   (tag_vtable_func)tag_write_start, (tag_vtable_func)NULL, /* wake_plc */
-
-                                   /* data accessors */
-                                   ab_get_int_attrib, ab_set_int_attrib,
-
-                                   ab_get_byte_array_attrib};
-
-
-int tag_read_start(ab_tag_p tag) {
-    return pccc_dhp_tag_read_start((ab_tag_p)tag, AB_EIP_SLC_RANGE_READ_FUNC);
-}
-
-int tag_write_start(ab_tag_p tag) {
-    return pccc_dhp_tag_write_start((ab_tag_p)tag, AB_EIP_SLC_RANGE_WRITE_FUNC);
-}

--- a/src/libplctag/protocols/ab/eip_slc_pccc.c
+++ b/src/libplctag/protocols/ab/eip_slc_pccc.c
@@ -31,29 +31,23 @@
  *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
  ***************************************************************************/
 
-#include <libplctag/lib/libplctag.h>
-#include <libplctag/protocols/ab/ab_common.h>
-#include <libplctag/protocols/ab/defs.h>
-#include <libplctag/protocols/ab/eip_slc_pccc.h>
-#include <libplctag/protocols/ab/error_codes.h>
-#include <libplctag/protocols/ab/pccc.h>
-#include <libplctag/protocols/ab/session.h>
 #include <libplctag/protocols/ab/tag.h>
-#include <utils/debug.h>
 
 
-static int tag_read_start(ab_tag_p tag);
-static int tag_write_start(ab_tag_p tag);
 
-struct tag_vtable_t slc_vtable = {(tag_vtable_func)ab_tag_abort_request, /* shared */
-                                   (tag_vtable_func)tag_read_start, (tag_vtable_func)pccc_tag_status, (tag_vtable_func)pccc_tag_tickler,
-                                   (tag_vtable_func)tag_write_start, (tag_vtable_func)NULL, /* wake_plc */
+struct tag_vtable_t slc_vtable = {
+    .abort = (tag_vtable_func)ab_tag_abort_request, /* shared */
+    .read = (tag_vtable_func)pccc_tag_read_start,
+    .status = (tag_vtable_func)pccc_tag_status,
+    .tickler = (tag_vtable_func)pccc_tag_tickler,
+    .write = (tag_vtable_func)pccc_tag_write_start,
+    .wake_plc = (tag_vtable_func)NULL, /* wake_plc */
 
-                                   /* data accessors */
-                                   ab_get_int_attrib, ab_set_int_attrib,
-
-                                   ab_get_byte_array_attrib};
-
+    /* data accessors */
+    .get_int_attrib = ab_get_int_attrib,
+    .set_int_attrib = ab_set_int_attrib,
+    .get_byte_array_attrib = ab_get_byte_array_attrib
+};
 
 
 /* default string types used for PLC-5 PLCs. */
@@ -77,10 +71,4 @@ tag_byte_order_t slc_tag_byte_order = {.is_allocated = 0,
                                        .str_total_length = 84,
                                        .str_pad_bytes = 0};
 
-int tag_read_start(ab_tag_p tag) {
-    return pccc_tag_read_start((ab_tag_p)tag, AB_EIP_SLC_RANGE_READ_FUNC);
-}
 
-int tag_write_start(ab_tag_p tag) {
-    return pccc_tag_write_start((ab_tag_p)tag, AB_EIP_SLC_RANGE_WRITE_FUNC);
-}

--- a/src/libplctag/protocols/ab/pccc.c
+++ b/src/libplctag/protocols/ab/pccc.c
@@ -141,15 +141,7 @@ START_PACK typedef struct {
     uint16_le dest_node;
     uint16_le src_link;
     uint16_le src_node;
-
-    /* PCCC Command */
-    uint8_t pccc_command;   /* CMD read, write etc. */
-    uint8_t pccc_status;    /* STS 0x00 in request */
-    uint16_le pccc_seq_num; /* TNS transaction/sequence id */
-    uint8_t pccc_function;  /* FNC sub-function of command */
-    uint16_le pccc_offset;  /* offset of requested in total request */
-    uint16_le pccc_transfer_size; /* total number of words requested */
-} END_PACK pccc_dhp_read_cmd_req;
+} END_PACK pccc_dhp_routing_header;
 
 START_PACK typedef struct {
     /* DH+ Routing */
@@ -214,11 +206,14 @@ static void encode_data(uint8_t *data, int *index, int val);
 
 static int pccc_check_read_status(ab_tag_p tag);
 static int pccc_check_write_status(ab_tag_p tag);
-static int pccc_tag_write_bit_start(ab_tag_p tag);
+static int plc5_tag_write_bit_start(ab_tag_p tag);
+static int slc_tag_write_bit_start(ab_tag_p tag);
 
 static int pccc_dhp_check_read_status(ab_tag_p tag);
 static int pccc_dhp_check_write_status(ab_tag_p tag);
-static int pccc_dhp_tag_write_bit_start(ab_tag_p tag);
+static int plc5_dhp_tag_write_bit_start(ab_tag_p tag);
+
+static int slc_dhp_tag_write_bit_start(ab_tag_p tag);
 
 /*
  * Public functions
@@ -1447,7 +1442,7 @@ int pccc_tag_tickler(ab_tag_p tag) {
  * Start a PCCC tag read (PLC5).
  */
 
-int pccc_tag_read_start(ab_tag_p tag, uint8_t pccc_func_code) {
+int pccc_tag_read_start(ab_tag_p tag) {
     int rc = PLCTAG_STATUS_OK;
     uint16_t conn_seq_id = (uint16_t)(session_get_new_seq_id(tag->session));
     ab_request_p req = NULL;
@@ -1491,7 +1486,7 @@ int pccc_tag_read_start(ab_tag_p tag, uint8_t pccc_func_code) {
 
         /* calculate request overhead */
         int request_overhead =   (int)sizeof(cip_pccc_req)
-                               + (pccc_func_code == AB_EIP_PLC5_RANGE_READ_FUNC ? (int)sizeof(plc5_pccc_read_cmd_req) : (int)sizeof(slc_pccc_read_cmd_req))
+                               + (tag->plc_type == AB_PLC_PLC5 ? (int)sizeof(plc5_pccc_read_cmd_req) : (int)sizeof(slc_pccc_read_cmd_req))
                                + tag->encoded_name_size
                                + 1;
 
@@ -1543,14 +1538,14 @@ int pccc_tag_read_start(ab_tag_p tag, uint8_t pccc_func_code) {
         cip_pccc->vendor_id = h2le16(AB_EIP_VENDOR_ID);
         cip_pccc->vendor_serial_number = h2le32(AB_EIP_VENDOR_SN);
 
-        if(pccc_func_code == AB_EIP_PLC5_RANGE_READ_FUNC) {
+        if(tag->plc_type == AB_PLC_PLC5) {
             plc5_pccc_read_cmd_req *pccc_cmd = (plc5_pccc_read_cmd_req *)(cip_pccc + 1);
     
             /* fill in PCCC command fields */
             pccc_cmd->pccc_command = AB_EIP_PCCC_TYPED_CMD;
             pccc_cmd->pccc_status = 0;
             pccc_cmd->pccc_seq_num = h2le16(conn_seq_id);
-            pccc_cmd->pccc_function = pccc_func_code;
+            pccc_cmd->pccc_function = AB_EIP_PLC5_RANGE_READ_FUNC;
             pccc_cmd->pccc_offset = h2le16(0);
             pccc_cmd->pccc_transfer_size = h2le16((uint16_t)(tag->size / 2)); /* size in words */
     
@@ -1563,7 +1558,7 @@ int pccc_tag_read_start(ab_tag_p tag, uint8_t pccc_func_code) {
             pccc_cmd->pccc_command = AB_EIP_PCCC_TYPED_CMD;
             pccc_cmd->pccc_status = 0;
             pccc_cmd->pccc_seq_num = h2le16(conn_seq_id);
-            pccc_cmd->pccc_function = pccc_func_code;
+            pccc_cmd->pccc_function = AB_EIP_SLC_RANGE_READ_FUNC;
             pccc_cmd->pccc_transfer_size = (uint8_t)tag->size; /* size in bytes */
 
             /* point data pointer just past the fixed data fields */
@@ -1574,7 +1569,7 @@ int pccc_tag_read_start(ab_tag_p tag, uint8_t pccc_func_code) {
         mem_copy(data, tag->encoded_name, tag->encoded_name_size);
         data += tag->encoded_name_size;
 
-        if(pccc_func_code == AB_EIP_PLC5_RANGE_READ_FUNC) {
+        if(tag->plc_type == AB_PLC_PLC5) {
             /* add data size byte */
             *data = (uint8_t)(tag->size);
             data++;
@@ -1710,7 +1705,7 @@ int pccc_check_read_status(ab_tag_p tag) {
 }
 
 
-int pccc_tag_write_start(ab_tag_p tag, uint8_t pccc_func_code) {
+int pccc_tag_write_start(ab_tag_p tag) {
     int rc = PLCTAG_STATUS_OK;
     ab_request_p req = NULL;
     uint16_t conn_seq_id = (uint16_t)(session_get_new_seq_id(tag->session));
@@ -1721,7 +1716,11 @@ int pccc_tag_write_start(ab_tag_p tag, uint8_t pccc_func_code) {
     pdebug(DEBUG_INFO, "Starting.");
 
     if(tag->is_bit) {
-        return pccc_tag_write_bit_start(tag);
+        if(tag->plc_type == AB_PLC_PLC5) {
+            return plc5_tag_write_bit_start(tag);
+        } else {
+            return slc_tag_write_bit_start(tag);
+        }
     }
 
     do {
@@ -1736,7 +1735,7 @@ int pccc_tag_write_start(ab_tag_p tag, uint8_t pccc_func_code) {
 
         /* How much overhead? */
         overhead =   sizeof(cip_pccc_req)
-                   + (pccc_func_code == AB_EIP_PLC5_RANGE_READ_FUNC ? sizeof(plc5_pccc_write_cmd_req) : sizeof(slc_pccc_write_cmd_req))
+                   + (tag->plc_type == AB_PLC_PLC5 ? sizeof(plc5_pccc_write_cmd_req) : sizeof(slc_pccc_write_cmd_req))
                    + (size_t)(unsigned int)tag->encoded_name_size
                    + 1;
 
@@ -1793,13 +1792,13 @@ int pccc_tag_write_start(ab_tag_p tag, uint8_t pccc_func_code) {
         cip_pccc->vendor_serial_number = h2le32(AB_EIP_VENDOR_SN);
 
         /* fill in PCCC command fields */
-        if(pccc_func_code == AB_EIP_PLC5_RANGE_READ_FUNC) {
+        if(tag->plc_type == AB_PLC_PLC5) {
             plc5_pccc_write_cmd_req *pccc_cmd = (plc5_pccc_write_cmd_req *)(cip_pccc + 1);
     
             pccc_cmd->pccc_command = AB_EIP_PCCC_TYPED_CMD;
             pccc_cmd->pccc_status = 0;
             pccc_cmd->pccc_seq_num = h2le16(conn_seq_id);
-            pccc_cmd->pccc_function = pccc_func_code;
+            pccc_cmd->pccc_function = AB_EIP_PLC5_RANGE_WRITE_FUNC;
             pccc_cmd->pccc_offset = h2le16(0);
             pccc_cmd->pccc_transfer_size = h2le16((uint16_t)(tag->size / 2)); // size is in bytes, PCCC transfer size is in words
 
@@ -1811,7 +1810,7 @@ int pccc_tag_write_start(ab_tag_p tag, uint8_t pccc_func_code) {
             pccc_cmd->pccc_command = AB_EIP_PCCC_TYPED_CMD;
             pccc_cmd->pccc_status = 0;
             pccc_cmd->pccc_seq_num = h2le16(conn_seq_id);
-            pccc_cmd->pccc_function = pccc_func_code;
+            pccc_cmd->pccc_function = AB_EIP_SLC_RANGE_WRITE_FUNC;
             pccc_cmd->pccc_transfer_size = (uint8_t)tag->size; /* size in bytes */
 
             /* point data pointer just past the fixed data fields */
@@ -1889,7 +1888,7 @@ int pccc_tag_write_start(ab_tag_p tag, uint8_t pccc_func_code) {
     return rc;
 }
 
-int pccc_tag_write_bit_start(ab_tag_p tag) {
+int plc5_tag_write_bit_start(ab_tag_p tag) {
     int rc = PLCTAG_STATUS_OK;
     ab_request_p req = NULL;
     uint16_t conn_seq_id = (uint16_t)(session_get_new_seq_id(tag->session));
@@ -2076,6 +2075,194 @@ int pccc_tag_write_bit_start(ab_tag_p tag) {
 }
 
 
+int slc_tag_write_bit_start(ab_tag_p tag) {
+    int rc = PLCTAG_STATUS_OK;
+    ab_request_p req = NULL;
+    uint16_t conn_seq_id = (uint16_t)(session_get_new_seq_id(tag->session));
+    uint8_t *data = NULL;
+    uint8_t *embed_start = NULL;
+    size_t overhead, data_per_packet;
+
+    pdebug(DEBUG_INFO, "Starting.");
+
+    do {
+        /* check for busy */
+        if(tag->read_in_progress || tag->write_in_progress) {
+            pdebug(DEBUG_WARN, "Read (%d) or write (%d) operation already in flight!", tag->read_in_progress, tag->write_in_progress);
+            rc = PLCTAG_ERR_BUSY;
+            break;
+        }
+
+        /* the mask is only 16 bits. */
+        if(tag->size != 2 || tag->elem_size != 2) {
+            pdebug(DEBUG_WARN, "Tag (%d bytes) and element size (%d bytes) must be 2 bytes!", tag->size, tag->elem_size);
+            rc = PLCTAG_ERR_UNSUPPORTED;
+            break;
+        }
+
+        tag->write_in_progress = 1;
+
+        /* How much overhead? */
+        overhead =   sizeof(cip_pccc_req)
+                   + sizeof(slc_pccc_write_cmd_req)
+                   + (size_t)(unsigned int)tag->encoded_name_size
+                   + 1;
+
+        int session_payload_space = session_get_available_cip_payload_space(tag->session);
+
+        if(session_payload_space <= 0) {
+            pdebug(DEBUG_WARN, "Unable to get valid payload space from session. Available payload: %d bytes", session_payload_space);
+            tag->write_in_progress = 0;
+            rc = PLCTAG_ERR_TOO_LARGE;
+            break;
+        }
+
+        data_per_packet = (size_t)session_payload_space - overhead;
+
+        if(data_per_packet <= 0) {
+            pdebug(DEBUG_WARN, "Unable to send request.  Packet overhead, %d bytes, is too large for available payload, %d bytes!",
+                   overhead, session_payload_space);
+            tag->write_in_progress = 0;
+            rc = PLCTAG_ERR_TOO_LARGE;
+            break;
+        }
+
+        if(data_per_packet < (size_t)tag->size) {
+            pdebug(DEBUG_WARN, "Tag size is %d, write overhead is %d, and write data per packet is %zu.", tag->size, overhead,
+                   data_per_packet);
+            tag->write_in_progress = 0;
+            rc = PLCTAG_ERR_TOO_LARGE;
+            break;
+        }
+
+        /* get a request buffer */
+        rc = session_create_request(tag->session, tag->tag_id, &req);
+        if(rc != PLCTAG_STATUS_OK) {
+            pdebug(DEBUG_WARN, "Unable to get new request.  rc=%d", rc);
+            tag->write_in_progress = 0;
+            break;
+        }
+
+        /* point the struct pointers to the buffer */
+        eip_cpf_uc_header *cip_req = (eip_cpf_uc_header *)(req->data);
+        cip_pccc_req *cip_pccc = (cip_pccc_req *)(cip_req + 1);
+        pccc_rmw_cmd_req *pccc_cmd = (pccc_rmw_cmd_req *)(cip_pccc + 1);
+        embed_start = (uint8_t *)(&cip_pccc->service_code);
+
+        /* fill in CIP/PCCC header fields */
+        cip_pccc->service_code = AB_EIP_CMD_PCCC_EXECUTE;
+        cip_pccc->req_path_size = 2;
+        cip_pccc->req_path[0] = 0x20;
+        cip_pccc->req_path[1] = 0x67;
+        cip_pccc->req_path[2] = 0x24;
+        cip_pccc->req_path[3] = 0x01;
+
+        cip_pccc->request_id_size = (uint8_t)(sizeof(cip_pccc->request_id_size) + sizeof(cip_pccc->vendor_id) + sizeof(cip_pccc->vendor_serial_number));
+        cip_pccc->vendor_id = h2le16(AB_EIP_VENDOR_ID);
+        cip_pccc->vendor_serial_number = h2le32(AB_EIP_VENDOR_SN);
+
+        /* fill in PCCC command fields */
+        pccc_cmd->pccc_command = AB_EIP_PCCC_TYPED_CMD;
+        pccc_cmd->pccc_status = 0;
+        pccc_cmd->pccc_seq_num = h2le16(conn_seq_id);
+        pccc_cmd->pccc_function = AB_EIP_SLC_RANGE_WRITE_MASK_FUNC;
+
+        /* point data pointer just past the fixed data fields */
+        data = (uint8_t *)(pccc_cmd + 1);
+
+        /* Add the transfer size. */
+        *data = (uint8_t)(tag->size & 0xFF);
+        data++;
+
+        /* copy encoded tag name into the request */
+        mem_copy(data, tag->encoded_name, tag->encoded_name_size);
+        data += tag->encoded_name_size;
+
+        /* The mask has bits set where the data will change the data file. */
+        for(int i = 0; i < tag->elem_size; i++) {
+            if((tag->bit / 8) == i) {
+                *data = (uint8_t)(1 << (tag->bit % 8));
+                pdebug(DEBUG_DETAIL, "adding mask byte %d: %x", i, *data);
+                data++;
+            } else {
+                *data = (uint8_t)0x00;
+                pdebug(DEBUG_DETAIL, "adding mask byte %d: %x", i, *data);
+                data++;
+            }
+        }
+
+        /* the set mask */
+        for(int i = 0; i < tag->elem_size; i++) {
+            *data = tag->data[i];
+            pdebug(DEBUG_DETAIL, "adding set byte %d: %x", i, *data);
+            data++;
+        }
+
+        /* debug: request full data length */
+        ptrdiff_t calculated_request_size = (ptrdiff_t)(data - req->data);
+        pdebug(DEBUG_DETAIL, "PCCC write request full data length: %td bytes.", calculated_request_size);
+
+        /* debug: dump request data */
+        pdebug(DEBUG_DETAIL, "PCCC write request data:");
+        pdebug_dump_bytes(DEBUG_DETAIL, req->data, (int)calculated_request_size);
+
+        /* debug: CIP data length */
+        ptrdiff_t cip_request_size = (ptrdiff_t)(data - embed_start);
+        pdebug(DEBUG_DETAIL, "PCCC write request CIP data length: %td bytes.", cip_request_size);
+
+        /* fill in Common Packet Format fields */
+        cip_req->cpf_item_count = h2le16(2);
+        cip_req->cpf_nai_item_type = h2le16(AB_EIP_ITEM_NAI);
+        cip_req->cpf_nai_item_length = h2le16(0);
+        cip_req->cpf_udi_item_type = h2le16(AB_EIP_ITEM_UDI);
+        cip_req->cpf_udi_item_length = h2le16((uint16_t)cip_request_size);
+
+        pdebug(DEBUG_DETAIL, "PCCC write request CPF UDI item length: %u bytes.", le2h16(cip_req->cpf_udi_item_length));
+
+        cip_req->router_timeout = h2le16(1);
+        cip_req->encap_command = h2le16(AB_EIP_UNCONNECTED_SEND);
+
+        /* set request size */
+        req->request_size = (int)calculated_request_size;
+        pdebug(DEBUG_DETAIL, "PCCC write request size set to %d bytes.", req->request_size);
+
+        /* add request to session */
+        rc = session_add_request(tag->session, req);
+        if(rc != PLCTAG_STATUS_OK) {
+            pdebug(DEBUG_WARN, "Unable to add write request to session! rc=%d", rc);
+            break;
+        }
+
+        rc = PLCTAG_STATUS_OK;
+    } while(0);
+
+    /* set tag->req if successful, else clean up */
+    if(rc == PLCTAG_STATUS_OK) {
+        critical_block(tag->api_mutex) {
+            if(tag->req) {
+                pdebug(DEBUG_WARN, "Request already set! This should not happen!");
+                rc = PLCTAG_ERR_BAD_DATA;
+            } else {
+                pdebug(DEBUG_INFO, "Setting write request for tag %d", tag->tag_id);
+                tag->req = req;
+                rc = PLCTAG_STATUS_PENDING;
+            }
+        }
+    } else {
+        pdebug(DEBUG_WARN, "Failed to generate new write request rc=%s", plc_tag_decode_error(rc));
+        req = rc_dec(req);
+        tag->write_in_progress = 0;
+        tag->write_complete = 1;
+        ab_tag_abort_request(tag);
+        return rc;
+    }
+
+    pdebug(DEBUG_INFO, "Done.");
+    return rc;
+}
+
+
+
 /*
  * check_write_status
  *
@@ -2196,7 +2383,7 @@ int pccc_dhp_tag_tickler(ab_tag_p tag) {
  * Start a PCCC tag read (PLC5).
  */
 
-int pccc_dhp_tag_read_start(ab_tag_p tag, uint8_t pccc_func_code) {
+int pccc_dhp_tag_read_start(ab_tag_p tag) {
     int rc = PLCTAG_STATUS_OK;
     uint16_t conn_seq_id = (uint16_t)(session_get_new_seq_id(tag->session));
     ab_request_p req = NULL;
@@ -2239,12 +2426,15 @@ int pccc_dhp_tag_read_start(ab_tag_p tag, uint8_t pccc_func_code) {
         }
 
         /* calculate request overhead */
-        int request_overhead =   (int)sizeof(pccc_dhp_read_cmd_req)
+        int request_overhead =   (int)sizeof(pccc_dhp_routing_header)
+                               + (int)(tag->plc_type == AB_PLC_PLC5 ? sizeof(plc5_pccc_read_cmd_req) : sizeof(slc_pccc_read_cmd_req))
                                + tag->encoded_name_size
                                + 1;
 
         pdebug(DEBUG_INFO, "PLC5 request overhead: PCCC read command header size %zu, encoded_name=%d, data_size=1, total=%d bytes",
-               sizeof(pccc_dhp_read_cmd_req), tag->encoded_name_size, request_overhead);
+               (tag->plc_type == AB_PLC_PLC5 ? sizeof(plc5_pccc_read_cmd_req) : sizeof(slc_pccc_read_cmd_req)), 
+               tag->encoded_name_size, 
+               request_overhead);
 
         int request_payload_space = cip_payload_space - request_overhead;
 
@@ -2276,26 +2466,39 @@ int pccc_dhp_tag_read_start(ab_tag_p tag, uint8_t pccc_func_code) {
 
         /* point the struct pointers to the buffer */
         eip_cpf_co_header *cip_req = (eip_cpf_co_header *)(req->data);
-        pccc_dhp_read_cmd_req *pccc_cmd = (pccc_dhp_read_cmd_req *)(cip_req + 1);
-
+        pccc_dhp_routing_header *dhp_routing = (pccc_dhp_routing_header *)(cip_req + 1);
         embed_start = (uint8_t *)(cip_req + 1);
 
         /* fill in DH+ fields */
-        pccc_cmd->dest_link = h2le16(0);
-        pccc_cmd->dest_node = h2le16(tag->session->dhp_dest);
-        pccc_cmd->src_link = h2le16(0);
-        pccc_cmd->src_node = h2le16(0);
+        dhp_routing->dest_link = h2le16(0);
+        dhp_routing->dest_node = h2le16(tag->session->dhp_dest);
+        dhp_routing->src_link = h2le16(0);
+        dhp_routing->src_node = h2le16(0);
 
-        /* fill in PCCC command fields */
-        pccc_cmd->pccc_command = AB_EIP_PCCC_TYPED_CMD;
-        pccc_cmd->pccc_status = 0;
-        pccc_cmd->pccc_seq_num = h2le16(conn_seq_id);
-        pccc_cmd->pccc_function = pccc_func_code;
-        pccc_cmd->pccc_offset = h2le16(0);
-        pccc_cmd->pccc_transfer_size = h2le16((uint16_t)(tag->size / 2));
+        if(tag->plc_type == AB_PLC_PLC5) {
+            plc5_pccc_read_cmd_req *pccc_cmd = (plc5_pccc_read_cmd_req *)(dhp_routing + 1);
 
-        /* point data pointer just past the fixed data fields */
-        data = (uint8_t *)(pccc_cmd + 1);
+            pccc_cmd->pccc_command = AB_EIP_PCCC_TYPED_CMD;
+            pccc_cmd->pccc_status = 0;
+            pccc_cmd->pccc_seq_num = h2le16(conn_seq_id);
+            pccc_cmd->pccc_function = AB_EIP_PLC5_RANGE_READ_FUNC;
+            pccc_cmd->pccc_offset = h2le16(0);
+            pccc_cmd->pccc_transfer_size = h2le16((uint16_t)(tag->size / 2));
+
+            /* point data pointer just past the fixed data fields */
+            data = (uint8_t *)(pccc_cmd + 1);
+        } else {
+            slc_pccc_read_cmd_req *pccc_cmd = (slc_pccc_read_cmd_req *)(dhp_routing + 1);
+
+            pccc_cmd->pccc_command = AB_EIP_PCCC_TYPED_CMD;
+            pccc_cmd->pccc_status = 0;
+            pccc_cmd->pccc_seq_num = h2le16(conn_seq_id);
+            pccc_cmd->pccc_function = AB_EIP_SLC_RANGE_READ_FUNC;
+            pccc_cmd->pccc_transfer_size = (uint8_t)tag->size;
+
+            /* point data pointer just past the fixed data fields */
+            data = (uint8_t *)(pccc_cmd + 1);
+        }
 
         pdebug(DEBUG_DETAIL, "DH+ PCCC request PCCC data 1:");
         pdebug_dump_bytes(DEBUG_DETAIL, req->data,
@@ -2309,9 +2512,11 @@ int pccc_dhp_tag_read_start(ab_tag_p tag, uint8_t pccc_func_code) {
         pdebug_dump_bytes(DEBUG_DETAIL, req->data,
                        (int)(data - req->data));
 
-        /* add data size byte */
-        *data = (uint8_t)(tag->size);
-        data++;
+        if(tag->plc_type == AB_PLC_PLC5) {
+            /* add data size byte */
+            *data = (uint8_t)(tag->size);
+            data++;
+        }
 
         pdebug(DEBUG_DETAIL, "DH+ PCCC request PCCC data 3:");
         pdebug_dump_bytes(DEBUG_DETAIL, req->data,
@@ -2441,7 +2646,7 @@ int pccc_dhp_check_read_status(ab_tag_p tag) {
 }
 
 
-int pccc_dhp_tag_write_start(ab_tag_p tag, uint8_t pccc_func_code) {
+int pccc_dhp_tag_write_start(ab_tag_p tag) {
     int rc = PLCTAG_STATUS_OK;
     ab_request_p req = NULL;
     uint16_t conn_seq_id = (uint16_t)(session_get_new_seq_id(tag->session));
@@ -2452,7 +2657,11 @@ int pccc_dhp_tag_write_start(ab_tag_p tag, uint8_t pccc_func_code) {
     pdebug(DEBUG_INFO, "Starting.");
 
     if(tag->is_bit) {
-        return pccc_dhp_tag_write_bit_start(tag);
+        if(tag->plc_type == AB_PLC_PLC5) {
+            return plc5_dhp_tag_write_bit_start(tag);
+        } else {
+            return slc_dhp_tag_write_bit_start(tag);
+        }
     }
 
     do {
@@ -2466,10 +2675,9 @@ int pccc_dhp_tag_write_start(ab_tag_p tag, uint8_t pccc_func_code) {
         tag->write_in_progress = 1;
 
         /* How much overhead? */
-        overhead =   sizeof(eip_cpf_co_header)
-                   + sizeof(pccc_dhp_write_cmd_req)
-                   + (size_t)(unsigned int)tag->encoded_name_size
-                   + 1;
+        overhead =   sizeof(pccc_dhp_routing_header)
+                   + (tag->plc_type == AB_PLC_PLC5 ? sizeof(plc5_pccc_write_cmd_req) : sizeof(slc_pccc_write_cmd_req))
+                   + (size_t)tag->encoded_name_size;
 
         int session_payload_space = session_get_available_cip_payload_space(tag->session);
 
@@ -2508,25 +2716,43 @@ int pccc_dhp_tag_write_start(ab_tag_p tag, uint8_t pccc_func_code) {
 
         /* point the struct pointers to the buffer */
         eip_cpf_co_header *cip_req = (eip_cpf_co_header *)(req->data);
-        pccc_dhp_write_cmd_req *pccc_cmd = (pccc_dhp_write_cmd_req *)(cip_req + 1);
+        pccc_dhp_routing_header *dhp_routing = (pccc_dhp_routing_header *)(cip_req + 1);
         embed_start = (uint8_t *)(cip_req + 1);
 
         /* fill in DH+ fields */
-        pccc_cmd->dest_link = h2le16(0);
-        pccc_cmd->dest_node = h2le16(tag->session->dhp_dest);
-        pccc_cmd->src_link = h2le16(0);
-        pccc_cmd->src_node = h2le16(0);
+        dhp_routing->dest_link = h2le16(0);
+        dhp_routing->dest_node = h2le16(tag->session->dhp_dest);
+        dhp_routing->src_link = h2le16(0);
+        dhp_routing->src_node = h2le16(0);
 
-        /* fill in PCCC command fields */
-        pccc_cmd->pccc_command = AB_EIP_PCCC_TYPED_CMD;
-        pccc_cmd->pccc_status = 0;
-        pccc_cmd->pccc_seq_num = h2le16(conn_seq_id);
-        pccc_cmd->pccc_function = pccc_func_code;
-        pccc_cmd->pccc_offset = h2le16(0);
-        pccc_cmd->pccc_transfer_size = h2le16((uint16_t)(tag->size / 2));
+        if(tag->plc_type == AB_PLC_PLC5) {
+            plc5_pccc_write_cmd_req *pccc_cmd = (plc5_pccc_write_cmd_req *)(dhp_routing + 1);
+            pdebug(DEBUG_DETAIL, "Using PLC5 PCCC write command request structure.");
 
-        /* point data pointer just past the fixed data fields */
-        data = (uint8_t *)(pccc_cmd + 1);
+            /* fill in PCCC command fields */
+            pccc_cmd->pccc_command = AB_EIP_PCCC_TYPED_CMD;
+            pccc_cmd->pccc_status = 0;
+            pccc_cmd->pccc_seq_num = h2le16(conn_seq_id);
+            pccc_cmd->pccc_function = AB_EIP_PLC5_RANGE_WRITE_FUNC;
+            pccc_cmd->pccc_offset = h2le16(0);
+            pccc_cmd->pccc_transfer_size = h2le16((uint16_t)(tag->size / 2));
+
+            /* point data pointer just past the fixed data fields */
+            data = (uint8_t *)(pccc_cmd + 1);
+        } else {
+            slc_pccc_write_cmd_req *pccc_cmd = (slc_pccc_write_cmd_req *)(dhp_routing + 1);
+            pdebug(DEBUG_DETAIL, "Using SLC PCCC write command request structure.");
+
+            /* fill in PCCC command fields */
+            pccc_cmd->pccc_command = AB_EIP_PCCC_TYPED_CMD;
+            pccc_cmd->pccc_status = 0;
+            pccc_cmd->pccc_seq_num = h2le16(conn_seq_id);
+            pccc_cmd->pccc_function = AB_EIP_SLC_RANGE_WRITE_FUNC;
+            pccc_cmd->pccc_transfer_size = (uint8_t)tag->size;
+
+            /* point data pointer just past the fixed data fields */
+            data = (uint8_t *)(pccc_cmd + 1);
+        }
 
         /* copy encoded tag name into the request */
         mem_copy(data, tag->encoded_name, tag->encoded_name_size);
@@ -2603,7 +2829,7 @@ int pccc_dhp_tag_write_start(ab_tag_p tag, uint8_t pccc_func_code) {
     return rc;
 }
 
-int pccc_dhp_tag_write_bit_start(ab_tag_p tag) {
+int plc5_dhp_tag_write_bit_start(ab_tag_p tag) {
     int rc = PLCTAG_STATUS_OK;
     ab_request_p req = NULL;
     uint16_t conn_seq_id = (uint16_t)(session_get_new_seq_id(tag->session));
@@ -2784,6 +3010,193 @@ int pccc_dhp_tag_write_bit_start(ab_tag_p tag) {
     pdebug(DEBUG_INFO, "Done.");
     return rc;
 }
+
+int slc_dhp_tag_write_bit_start(ab_tag_p tag) {
+    int rc = PLCTAG_STATUS_OK;
+    ab_request_p req = NULL;
+    uint16_t conn_seq_id = (uint16_t)(session_get_new_seq_id(tag->session));
+    uint8_t *data = NULL;
+    uint8_t *embed_start = NULL;
+    size_t overhead = 0;
+    int data_per_packet = 0;
+
+    pdebug(DEBUG_INFO, "Starting.");
+
+    do {
+        /* check for busy */
+        if(tag->read_in_progress || tag->write_in_progress) {
+            pdebug(DEBUG_WARN, "Read (%d) or write (%d) operation already in flight!", tag->read_in_progress, tag->write_in_progress);
+            rc = PLCTAG_ERR_BUSY;
+            break;
+        }
+
+        /* the mask is only 16 bits. */
+        if(tag->size != 2 || tag->elem_size != 2) {
+            pdebug(DEBUG_WARN, "Unsupported tag size or element size: %d, %d", tag->size, tag->elem_size);
+            rc = PLCTAG_ERR_UNSUPPORTED;
+            break;
+        }
+
+        tag->write_in_progress = 1;
+
+        /* How much overhead? */
+        overhead =   sizeof(eip_cpf_co_header)
+                   + sizeof(pccc_dhp_routing_header)
+                   + sizeof(slc_pccc_write_cmd_req)
+                   + (size_t)tag->encoded_name_size
+                   + (size_t)(tag->elem_size)
+                   + 2; /* the mask */
+
+        int session_payload_space = session_get_available_cip_payload_space(tag->session);
+
+        if(session_payload_space <= 0) {
+            pdebug(DEBUG_WARN, "Unable to get valid payload space from session. Available payload: %d bytes", session_payload_space);
+            tag->write_in_progress = 0;
+            rc = PLCTAG_ERR_TOO_LARGE;
+            break;
+        }
+
+        data_per_packet = session_payload_space - (int)overhead;
+
+        if(data_per_packet < 0) {
+            pdebug(DEBUG_WARN, "Unable to send request.  Packet overhead, %zu bytes, is too large for available payload, %d bytes!",
+                   overhead, session_payload_space);
+            tag->write_in_progress = 0;
+            rc = PLCTAG_ERR_TOO_LARGE;
+            break;
+        }
+
+        /* check if we can fit the AND/OR masks in the packet */
+        if(data_per_packet < (int)(tag->elem_size * 2)) {
+            pdebug(DEBUG_WARN, "Tag elem_size is %d, write overhead is %zu, and write data per packet is %zu.", tag->elem_size, overhead,
+                   data_per_packet);
+            tag->write_in_progress = 0;
+            rc = PLCTAG_ERR_TOO_LARGE;
+            break;
+        }
+
+        /* get a request buffer */
+        rc = session_create_request(tag->session, tag->tag_id, &req);
+        if(rc != PLCTAG_STATUS_OK) {
+            pdebug(DEBUG_WARN, "Unable to get new request.  rc=%d", rc);
+            tag->write_in_progress = 0;
+            break;
+        }
+
+        /* stack the struct pointers as in tag_read_start */
+        eip_cpf_co_header *cip_req = (eip_cpf_co_header *)(req->data);
+        pccc_dhp_rmw_cmd_req *pccc_cmd = (pccc_dhp_rmw_cmd_req *)(cip_req + 1);
+        embed_start = (uint8_t *)(cip_req + 1);
+
+        /* point data pointer just past the fixed data fields */
+        data = (uint8_t *)(pccc_cmd + 1);
+
+        /* Add the transfer size. */
+        *data = (uint8_t)(tag->size & 0xFF);
+        data++;
+
+        /* copy encoded tag name into the request */
+        mem_copy(data, tag->encoded_name, tag->encoded_name_size);
+        data += tag->encoded_name_size;
+
+        /* The mask has bits set where the data will change the data file. */
+        for(int i = 0; i < tag->elem_size; i++) {
+            if((tag->bit / 8) == i) {
+                *data = (uint8_t)(1 << (tag->bit % 8));
+                pdebug(DEBUG_DETAIL, "adding mask byte %d: %x", i, *data);
+                data++;
+            } else {
+                *data = (uint8_t)0x00;
+                pdebug(DEBUG_DETAIL, "adding mask byte %d: %x", i, *data);
+                data++;
+            }
+        }
+
+        /* the set mask */
+        for(int i = 0; i < tag->elem_size; i++) {
+            *data = tag->data[i];
+            pdebug(DEBUG_DETAIL, "adding set byte %d: %x", i, *data);
+            data++;
+        }
+
+        /* debug: request full data length */
+        ptrdiff_t calculated_request_size = (ptrdiff_t)(data - req->data);
+        pdebug(DEBUG_DETAIL, "DH+ SLC bit write request full data length: %td bytes.", calculated_request_size);
+
+        /* debug: dump request data */
+        pdebug(DEBUG_DETAIL, "DH+ SLC bit write request data:");
+        pdebug_dump_bytes(DEBUG_DETAIL, req->data, (int)calculated_request_size);
+
+        /* debug: CIP data length */
+        ptrdiff_t cip_request_size = (ptrdiff_t)(data - embed_start);
+        pdebug(DEBUG_DETAIL, "DH+ SLC bit write request CIP data length: %td bytes.", cip_request_size);
+
+        /* fill in DH+ fields */
+        pccc_cmd->dest_link = h2le16(0);
+        pccc_cmd->dest_node = h2le16(tag->session->dhp_dest);
+        pccc_cmd->src_link = h2le16(0);
+        pccc_cmd->src_node = h2le16(0);
+
+        /* fill in PCCC command fields */
+        pccc_cmd->pccc_command = AB_EIP_PCCC_TYPED_CMD;
+        pccc_cmd->pccc_status = 0;
+        pccc_cmd->pccc_seq_num = h2le16(conn_seq_id);
+        pccc_cmd->pccc_function = AB_EIP_SLC_RANGE_WRITE_MASK_FUNC;
+
+        /* fill in Common Packet Format fields */
+        cip_req->cpf_item_count = h2le16(2);
+        cip_req->cpf_cai_item_type = h2le16(AB_EIP_ITEM_CAI);
+        cip_req->cpf_cai_item_length = h2le16(4);
+        cip_req->cpf_targ_conn_id = h2le32(tag->session->targ_connection_id);
+        cip_req->cpf_cdi_item_type = h2le16(AB_EIP_ITEM_CDI);
+        cip_req->cpf_conn_seq_num = h2le16(conn_seq_id);
+        cip_req->cpf_cdi_item_length = h2le16((uint16_t)((size_t)cip_request_size + sizeof(cip_req->cpf_conn_seq_num)));
+
+        pdebug(DEBUG_DETAIL, "DH+ PCCC bit write request CPF CDI item length: %u bytes.", le2h16(cip_req->cpf_cdi_item_length));
+
+        cip_req->router_timeout = h2le16(1);
+        cip_req->encap_command = h2le16(AB_EIP_CONNECTED_SEND);
+
+        /* set request size */
+        req->request_size = (int)calculated_request_size;
+        pdebug(DEBUG_DETAIL, "DH+ PCCC bit write request size set to %d bytes.", req->request_size);
+
+        /* add request to session */
+        rc = session_add_request(tag->session, req);
+        if(rc != PLCTAG_STATUS_OK) {
+            pdebug(DEBUG_WARN, "Unable to add bit write request to session! rc=%d", rc);
+            break;
+        }
+
+        rc = PLCTAG_STATUS_OK;
+    } while(0);
+
+    /* set tag->req if successful, else clean up */
+    if(rc == PLCTAG_STATUS_OK) {
+        critical_block(tag->api_mutex) {
+            if(tag->req) {
+                pdebug(DEBUG_WARN, "Request already set! This should not happen!");
+                rc = PLCTAG_ERR_BAD_DATA;
+            } else {
+                pdebug(DEBUG_INFO, "Setting bit write request for tag %d", tag->tag_id);
+                tag->req = req;
+                rc = PLCTAG_STATUS_PENDING;
+            }
+        }
+    } else {
+        pdebug(DEBUG_WARN, "Failed to generate new bit write request rc=%s", plc_tag_decode_error(rc));
+        req = rc_dec(req);
+        tag->write_in_progress = 0;
+        tag->write_complete = 1;
+        ab_tag_abort_request(tag);
+        return rc;
+    }
+
+    pdebug(DEBUG_INFO, "Done.");
+    return rc;
+}
+
+
 
 
 /*

--- a/src/libplctag/protocols/ab/pccc.h
+++ b/src/libplctag/protocols/ab/pccc.h
@@ -86,13 +86,13 @@ extern int pccc_encode_dt_byte(uint8_t *data,int buf_size, uint32_t data_type, u
 /* generic direct ethernet tag functions */
 extern int pccc_tag_status(ab_tag_p tag);
 extern int pccc_tag_tickler(ab_tag_p tag);
-extern int pccc_tag_read_start(ab_tag_p tag, uint8_t pccc_cmd);
-extern int pccc_tag_write_start(ab_tag_p tag, uint8_t pccc_cmd);
+extern int pccc_tag_read_start(ab_tag_p tag);
+extern int pccc_tag_write_start(ab_tag_p tag);
 
 /* PCCC over DH+ */
 extern int pccc_dhp_tag_status(ab_tag_p tag);
 extern int pccc_dhp_tag_tickler(ab_tag_p tag);
-extern int pccc_dhp_tag_read_start(ab_tag_p tag, uint8_t pccc_cmd);
-extern int pccc_dhp_tag_write_start(ab_tag_p tag, uint8_t pccc_cmd);
+extern int pccc_dhp_tag_read_start(ab_tag_p tag);
+extern int pccc_dhp_tag_write_start(ab_tag_p tag);
 
 #endif

--- a/src/tests/run_full_tests.sh
+++ b/src/tests/run_full_tests.sh
@@ -184,8 +184,30 @@ else
 fi
 
 let TEST++
+echo -n "Test $TEST: B data file Micrologix tag read/write... "
+$VALGRIND$TEST_DIR/tag_rw2 --type=uint16 '--tag=protocol=ab-eip&gateway=10.206.1.36&plc=micrologix&name=B3:0' --write=0 --debug=4 > "${TEST}_micrologix.log" 2>&1
+if [ $? != 0 ]; then
+    echo "FAILURE"
+    let FAILURES++
+else
+    echo "OK"
+    let SUCCESSES++
+fi
+
+let TEST++
+echo -n "Test $TEST: B bit data file Micrologix tag read/write... "
+$VALGRIND$TEST_DIR/tag_rw2 --type=bit '--tag=protocol=ab-eip&gateway=10.206.1.36&plc=micrologix&name=B3:0/6' --write=1 --debug=4 > "${TEST}_micrologix.log" 2>&1
+if [ $? != 0 ]; then
+    echo "FAILURE"
+    let FAILURES++
+else
+    echo "OK"
+    let SUCCESSES++
+fi
+
+let TEST++
 echo -n "Test $TEST: N data file Micrologix tag read/write... "
-$VALGRIND$TEST_DIR/tag_rw2 --type=sint16 '--tag=protocol=ab-eip&gateway=10.206.1.36&plc=micrologix&elem_count=1&name=N7:0' --write=42 --debug=4 > "${TEST}_micrologix.log" 2>&1
+$VALGRIND$TEST_DIR/tag_rw2 --type=sint16 '--tag=protocol=ab-eip&gateway=10.206.1.36&plc=micrologix&name=N7:0' --write=42 --debug=4 > "${TEST}_micrologix.log" 2>&1
 if [ $? != 0 ]; then
     echo "FAILURE"
     let FAILURES++
@@ -196,7 +218,7 @@ fi
 
 let TEST++
 echo -n "Test $TEST: N bit data file Micrologix tag read/write... "
-$VALGRIND$TEST_DIR/tag_rw2 --type=bit '--tag=protocol=ab-eip&gateway=10.206.1.36&plc=micrologix&elem_count=1&name=N7:0/10' --write=1 --debug=4 > "${TEST}_micrologix.log" 2>&1
+$VALGRIND$TEST_DIR/tag_rw2 --type=bit '--tag=protocol=ab-eip&gateway=10.206.1.36&plc=micrologix&name=N7:0/10' --write=1 --debug=4 > "${TEST}_micrologix.log" 2>&1
 if [ $? != 0 ]; then
     echo "FAILURE"
     let FAILURES++
@@ -217,31 +239,20 @@ else
 fi
 
 let TEST++
-echo -n "Test $TEST: L bit data file Micrologix tag read/write... "
+echo -n "Test $TEST: L bit data file Micrologix tag read... "
+$VALGRIND$TEST_DIR/tag_rw2 --type=bit '--tag=protocol=ab-eip&gateway=10.206.1.36&plc=micrologix&name=L10:0/23' --debug=4 > "${TEST}_micrologix.log" 2>&1
+if [ $? != 0 ]; then
+    echo "FAILURE"
+    let FAILURES++
+else
+    echo "OK"
+    let SUCCESSES++
+fi
+
+let TEST++
+echo -n "Test $TEST: L bit data file Micrologix tag write... "
 $VALGRIND$TEST_DIR/tag_rw2 --type=bit '--tag=protocol=ab-eip&gateway=10.206.1.36&plc=micrologix&name=L10:0/23' --write=1 --debug=4 > "${TEST}_micrologix.log" 2>&1
-if [ $? != 0 ]; then
-    echo "FAILURE"
-    let FAILURES++
-else
-    echo "OK"
-    let SUCCESSES++
-fi
-
-let TEST++
-echo -n "Test $TEST: B data file Micrologix tag read/write... "
-$VALGRIND$TEST_DIR/tag_rw2 --type=uint16 '--tag=protocol=ab-eip&gateway=10.206.1.36&plc=micrologix&elem_count=1&name=B3:0' --write=0 --debug=4 > "${TEST}_micrologix.log" 2>&1
-if [ $? != 0 ]; then
-    echo "FAILURE"
-    let FAILURES++
-else
-    echo "OK"
-    let SUCCESSES++
-fi
-
-let TEST++
-echo -n "Test $TEST: B bit data file Micrologix tag read/write... "
-$VALGRIND$TEST_DIR/tag_rw2 --type=bit '--tag=protocol=ab-eip&gateway=10.206.1.36&plc=micrologix&elem_count=4&name=B3:0/6' --write=1 --debug=4 > "${TEST}_micrologix.log" 2>&1
-if [ $? != 0 ]; then
+if [ $? == 0 ]; then   # this should NOT succeed
     echo "FAILURE"
     let FAILURES++
 else

--- a/src/tests/run_simulator_tests.sh
+++ b/src/tests/run_simulator_tests.sh
@@ -257,7 +257,7 @@ sleep 1
 
 let TEST++
 echo -n "  Test $TEST: B data file Micrologix tag read/write... "
-$VALGRIND$TEST_DIR/tag_rw2 --type=uint16 '--tag=protocol=ab-eip&gateway=127.0.0.1&plc=micrologix&elem_count=1&name=B3:0' --write=0 --debug=4 > "${TEST}_micrologix.log" 2>&1
+$VALGRIND$TEST_DIR/tag_rw2 --type=uint16 '--tag=protocol=ab-eip&gateway=127.0.0.1&plc=micrologix&name=B3:0' --write=0 --debug=4 > "${TEST}_micrologix.log" 2>&1
 if [ $? != 0 ]; then
     echo "FAILURE"
     let FAILURES++
@@ -268,7 +268,7 @@ fi
 
 let TEST++
 echo -n "  Test $TEST: B bit data file Micrologix tag read/write... "
-$VALGRIND$TEST_DIR/tag_rw2 --type=bit '--tag=protocol=ab-eip&gateway=127.0.0.1&plc=micrologix&elem_count=4&name=B3:0/6' --write=1 --debug=4 > "${TEST}_micrologix.log" 2>&1
+$VALGRIND$TEST_DIR/tag_rw2 --type=bit '--tag=protocol=ab-eip&gateway=127.0.0.1&plc=micrologix&name=B3:0/6' --write=1 --debug=4 > "${TEST}_micrologix.log" 2>&1
 if [ $? != 0 ]; then
     echo "FAILURE"
     let FAILURES++
@@ -279,7 +279,7 @@ fi
 
 let TEST++
 echo -n "  Test $TEST: N data file Micrologix tag read/write... "
-$VALGRIND$TEST_DIR/tag_rw2 --type=sint16 '--tag=protocol=ab-eip&gateway=127.0.0.1&plc=micrologix&elem_count=1&name=N7:0' --write=42 --debug=4 > "${TEST}_micrologix.log" 2>&1
+$VALGRIND$TEST_DIR/tag_rw2 --type=sint16 '--tag=protocol=ab-eip&gateway=127.0.0.1&plc=micrologix&name=N7:0' --write=42 --debug=4 > "${TEST}_micrologix.log" 2>&1
 if [ $? != 0 ]; then
     echo "FAILURE"
     let FAILURES++
@@ -290,7 +290,7 @@ fi
 
 let TEST++
 echo -n "  Test $TEST: N bit data file Micrologix tag read/write... "
-$VALGRIND$TEST_DIR/tag_rw2 --type=bit '--tag=protocol=ab-eip&gateway=127.0.0.1&plc=micrologix&elem_count=1&name=N7:0/10' --write=1 --debug=4 > "${TEST}_micrologix.log" 2>&1
+$VALGRIND$TEST_DIR/tag_rw2 --type=bit '--tag=protocol=ab-eip&gateway=127.0.0.1&plc=micrologix&name=N7:0/10' --write=1 --debug=4 > "${TEST}_micrologix.log" 2>&1
 if [ $? != 0 ]; then
     echo "FAILURE"
     let FAILURES++
@@ -301,7 +301,7 @@ fi
 
 let TEST++
 echo -n "  Test $TEST: L data file Micrologix tag read/write... "
-$VALGRIND$TEST_DIR/tag_rw2 --type=sint32 '--tag=protocol=ab-eip&gateway=127.0.0.1&plc=micrologix&elem_count=4&name=L10:0' --write=0,1,2,3 --debug=4 > "${TEST}_micrologix.log" 2>&1
+$VALGRIND$TEST_DIR/tag_rw2 --type=sint32 '--tag=protocol=ab-eip&gateway=127.0.0.1&plc=micrologix&name=L10:0' --write=0,1,2,3 --debug=4 > "${TEST}_micrologix.log" 2>&1
 if [ $? != 0 ]; then
     echo "FAILURE"
     let FAILURES++
@@ -311,9 +311,19 @@ else
 fi
 
 let TEST++
-echo -n "  Test $TEST: L bit data file Micrologix tag read/write... "
-$VALGRIND$TEST_DIR/tag_rw2 --type=bit '--tag=protocol=ab-eip&gateway=127.0.0.1&plc=micrologix&name=L10:0/23' --write=1 --debug=4 > "${TEST}_micrologix.log" 2>&1
+echo -n "  Test $TEST: L bit data file Micrologix tag read... "
+$VALGRIND$TEST_DIR/tag_rw2 --type=bit '--tag=protocol=ab-eip&gateway=127.0.0.1&plc=micrologix&name=L10:0/23' --debug=4 > "${TEST}_micrologix.log" 2>&1
 if [ $? != 0 ]; then
+    echo "FAILURE"
+    let FAILURES++
+else
+    echo "OK"
+    let SUCCESSES++
+fi
+let TEST++
+echo -n "  Test $TEST: L bit data file Micrologix tag write... "
+$VALGRIND$TEST_DIR/tag_rw2 --type=bit '--tag=protocol=ab-eip&gateway=127.0.0.1&plc=micrologix&name=L10:0/23' --write=1 --debug=4 > "${TEST}_micrologix.log" 2>&1
+if [ $? == 0 ]; then    # This should _NOT_ succeed
     echo "FAILURE"
     let FAILURES++
 else


### PR DESCRIPTION
Thanks again to user @mikecflood for finding this.   Writes to single bits of SLC or Micrologix were not working correctly.   Unfortunately, the functions supported by the SLC/Micrologix PLCs do not allow for good RMW (read-modify-write) support.   Oddly, the PLC5 series has much better support!

On a SLC/Micrologix PLC you can only write with a 16-bit mask.   Due to that I have limited the support for single bit writes (via bit tags) to those tags that are 16 bits.  This includes single elements from the B and N files.  You can read a bit tag from nearly anything, but not write.

I would really appreciate it if those of you who have SLC or Micrologix PLCs hung off of DH+ that can be bridged from a ControlLogix could test this.   I do not have such a configuration so the code for that path is untested.

This fixes issue #572.

You can find this release [here](https://github.com/libplctag/libplctag/releases/tag/v2.6.11).