### PR TITLE
Add LTIME to lookup types

### DIFF
--- a/src/examples/list_tags_logix.c
+++ b/src/examples/list_tags_logix.c
@@ -657,6 +657,7 @@ void print_element_type(uint16_t element_type) {
             case 0xDC: type = "CIP path segment(s)"; break;
             case 0xDD: type = "Engineering units"; break;
             case 0xDE: type = "International character string (encoding?)"; break;
+            case 0xDF: type = "LTIME: Long duration of time. 64-bit storage; units are in nanoseconds."; break;
         }
 
         if(type) {

--- a/src/examples/list_tags_micro8x0.c
+++ b/src/examples/list_tags_micro8x0.c
@@ -645,6 +645,7 @@ void print_element_type(uint16_t element_type) {
             case 0xDC: type = "CIP path segment(s)"; break;
             case 0xDD: type = "Engineering units"; break;
             case 0xDE: type = "International character string (encoding?)"; break;
+            case 0xDF: type = "LTIME: Long duration of time. 64-bit storage; units are in nanoseconds."; break;
         }
 
         if(type) {

--- a/src/libplctag/protocols/ab/cip.c
+++ b/src/libplctag/protocols/ab/cip.c
@@ -1017,7 +1017,7 @@ static struct cip_type_lookup_entry_t cip_type_lookup[] = {
     /* 0xdc */ {PLCTAG_STATUS_OK, 2, 0},  /* EPATH: CIP path segment(s) */
     /* 0xdd */ {PLCTAG_STATUS_OK, 2, 2},  /* ENGUNIT: Engineering units */
     /* 0xde */ {PLCTAG_STATUS_OK, 2, 0},  /* STRINGI: International character string (encoding?) */
-    /* 0xdf */ {PLCTAG_ERR_NO_MATCH, 0, 0},
+    /* 0xdf */ {PLCTAG_STATUS_OK, 2, 8},  /* LTIME: Large time value */
     /* 0xe0 */ {PLCTAG_ERR_NO_MATCH, 0, 0},
     /* 0xe1 */ {PLCTAG_ERR_NO_MATCH, 0, 0},
     /* 0xe2 */ {PLCTAG_ERR_NO_MATCH, 0, 0},

--- a/src/libplctag/protocols/omron/cip.c
+++ b/src/libplctag/protocols/omron/cip.c
@@ -1012,7 +1012,7 @@ static struct cip_type_lookup_entry_t cip_type_lookup[] = {
     /* 0xdc */ {PLCTAG_STATUS_OK, 2, 0},  /* EPATH: CIP path segment(s) */
     /* 0xdd */ {PLCTAG_STATUS_OK, 2, 2},  /* ENGUNIT: Engineering units */
     /* 0xde */ {PLCTAG_STATUS_OK, 2, 0},  /* STRINGI: International character string (encoding?) */
-    /* 0xdf */ {PLCTAG_ERR_NO_MATCH, 0, 0},
+    /* 0xdf */ {PLCTAG_STATUS_OK, 2, 8},  /* LTIME: Large time value */
     /* 0xe0 */ {PLCTAG_ERR_NO_MATCH, 0, 0},
     /* 0xe1 */ {PLCTAG_ERR_NO_MATCH, 0, 0},
     /* 0xe2 */ {PLCTAG_ERR_NO_MATCH, 0, 0},


### PR DESCRIPTION
LTIME does not exists in lookup table, adds it. LTIME was added in Studio5000 v34 I guess?