### PR TITLE
Make windows imports mingw compatible

### DIFF
--- a/src/examples/compat_utils.h
+++ b/src/examples/compat_utils.h
@@ -66,7 +66,7 @@ typedef pthread_cond_t compat_cond_t;
 
 #    define WIN32_LEAN_AND_MEAN
 
-#    include <Windows.h>
+#    include <windows.h>
 
 #    include <time.h>
 

--- a/src/platform/windows/platform.c
+++ b/src/platform/windows/platform.c
@@ -38,11 +38,11 @@
 #include <platform.h>
 
 /* KEEP THE SPACES BETWEEN THE INCLUDES.  The order is required! */
-#include <Winsock2.h>
+#include <winsock2.h>
 
-#include <Windows.h>
+#include <windows.h>
 
-#include <Ws2tcpip.h>
+#include <ws2tcpip.h>
 
 #include <errno.h>
 #include <io.h>

--- a/src/platform/windows/platform.h
+++ b/src/platform/windows/platform.h
@@ -47,11 +47,11 @@ extern "C"
 */
 
 /* KEEP THE SPACES BETWEEN LINES!  The order is required! */
-#include <Winsock2.h>
+#include <winsock2.h>
 
 #include <windows.h>
 
-#include <Ws2tcpip.h>
+#include <ws2tcpip.h>
 
 
 #include <tchar.h>

--- a/src/tests/ab_server/src/main.c
+++ b/src/tests/ab_server/src/main.c
@@ -41,7 +41,7 @@
 #include <time.h>
 
 #if defined(IS_WINDOWS)
-#    include <Windows.h>
+#    include <windows.h>
 #else
 /* assume it is POSIX of some sort... */
 #    include <signal.h>

--- a/src/tests/ab_server/src/utils.c
+++ b/src/tests/ab_server/src/utils.c
@@ -62,9 +62,9 @@
 #    define PLATFORM_WINDOWS
 
 /* Windows include file order is important! */
-#    include <Winsock2.h>
-#    include <Windows.h>
-#    include <Ws2tcpip.h>
+#    include <winsock2.h>
+#    include <windows.h>
+#    include <ws2tcpip.h>
 #    include <io.h>
 #    include <tchar.h>
 #    include <strsafe.h>

--- a/src/tests/utils/atomic_utils.c
+++ b/src/tests/utils/atomic_utils.c
@@ -46,7 +46,7 @@
 
 #    ifdef _WIN32
 #       define WIN32_LEAN_AND_MEAN
-#       include <Windows.h>
+#       include <windows.h>
 #    endif
 
 void atomic_init_bool(atomic_bool *a, bool new_val) { *a = new_val; }

--- a/src/utils/atomic_utils.c
+++ b/src/utils/atomic_utils.c
@@ -47,7 +47,7 @@
 
 #    ifdef _WIN32
 #       define WIN32_LEAN_AND_MEAN
-#       include <Windows.h>
+#       include <windows.h>
 #    endif
 
 void atomic_init_bool(atomic_bool *a, bool new_val) { *a = new_val; }

--- a/src/utils/random_utils.c
+++ b/src/utils/random_utils.c
@@ -76,7 +76,7 @@ uint64_t random_u64(uint64_t upper_bound) {
 
 
 #elif defined(_WIN32) || defined(_WIN64)
-#include <Windows.h>
+#include <windows.h>
 
 #include <wincrypt.h>
 


### PR DESCRIPTION
Under Linux mingw is case sensitive, if we want to cross compile capital W breaks compilation

This is a special merge to make the PR work on the updated prerelease branch.