### PR TITLE
ab_server: scope CIP_SRV_UNCONNECTED_SEND case body

### DIFF
--- a/src/tools/ab_server/cip.c
+++ b/src/tools/ab_server/cip.c
@@ -168,7 +168,7 @@ slice_s cip_dispatch_unconnected_request(slice_s input, slice_s output, plc_s *p
 
         case CIP_SRV_PCCC_EXECUTE: return dispatch_pccc_request(input, output, plc); break;
 
-        case CIP_SRV_UNCONNECTED_SEND:
+        case CIP_SRV_UNCONNECTED_SEND: {
             /* we've stripped off the CM part, but there is a byte count of the remaining data that we need. */
             uint16_t embedded_cip_service_length = slice_get_uint16_le(cip_service_payload, 2);
 
@@ -180,6 +180,7 @@ slice_s cip_dispatch_unconnected_request(slice_s input, slice_s output, plc_s *p
             }
 
             return cip_dispatch_request(slice_from_slice(cip_service_payload, 4, embedded_cip_service_length), output, plc);
+        }
             break;
 
         default: return make_cip_log_error(output, cip_service, CIP_ERR_UNSUPPORTED, false, 0); break;


### PR DESCRIPTION
This scopes the `CIP_SRV_UNCONNECTED_SEND` case body in `src/tools/ab_server/cip.c` so declarations are valid in C11 builds.

Related Homebrew source-build failure and fix context:
- https://github.com/Homebrew/homebrew-core/pull/269933
