### PR TITLE
Remove SO_LINGER option

### DIFF
--- a/src/platform/posix/platform.c
+++ b/src/platform/posix/platform.c
@@ -1173,7 +1173,6 @@ int socket_connect_tcp_start(sock_p s, const char *host, int port) {
     int done = 0;
     int fd;
     int flags;
-    struct linger so_linger; /* used to set up short/no lingering after connections are close()ed. */
 
     pdebug(DEBUG_MODULE_PLATFORM, DEBUG_DETAIL, 0, "Starting.");
 
@@ -1212,16 +1211,6 @@ int socket_connect_tcp_start(sock_p s, const char *host, int port) {
      * 3. select() provides finer control over timeout behavior than SO_RCVTIMEO/SO_SNDTIMEO
      * Instead, timeout handling is done via select() in socket_wait_event() and socket_read()
      */
-
-    /* abort the connection immediately upon close. */
-    so_linger.l_onoff = 1;
-    so_linger.l_linger = 0;
-
-    if(setsockopt(fd, SOL_SOCKET, SO_LINGER, (char *)&so_linger, sizeof(so_linger))) {
-        close(fd);
-        pdebug(DEBUG_MODULE_PLATFORM, DEBUG_ERROR, 0, "Error setting socket close linger option, errno: %d", errno);
-        return PLCTAG_ERR_OPEN;
-    }
 
     /* make the socket non-blocking. */
     flags = fcntl(fd, F_GETFL, 0);

--- a/src/platform/windows/platform.c
+++ b/src/platform/windows/platform.c
@@ -1224,7 +1224,6 @@ int socket_connect_tcp_start(sock_p s, const char *host, int port) {
     int done = 0;
     SOCKET fd;
     struct timeval timeout; /* used for timing out connections etc. */
-    struct linger so_linger;
 
     pdebug(DEBUG_MODULE_PLATFORM, DEBUG_SPEW, 0, "Starting.");
 
@@ -1258,16 +1257,6 @@ int socket_connect_tcp_start(sock_p s, const char *host, int port) {
     if(setsockopt(fd, SOL_SOCKET, SO_SNDTIMEO, (char *)&timeout, (int)sizeof(timeout))) {
         closesocket(fd);
         pdebug(DEBUG_MODULE_PLATFORM, DEBUG_WARN, 0, "Error setting socket send timeout option, errno: %d", errno);
-        return PLCTAG_ERR_OPEN;
-    }
-
-    /* abort the connection on close. */
-    so_linger.l_onoff = 1;
-    so_linger.l_linger = 0;
-
-    if(setsockopt(fd, SOL_SOCKET, SO_LINGER, (char *)&so_linger, (int)sizeof(so_linger))) {
-        closesocket(fd);
-        pdebug(DEBUG_MODULE_PLATFORM, DEBUG_WARN, 0, "Error setting socket close linger option, errno: %d", errno);
         return PLCTAG_ERR_OPEN;
     }
 


### PR DESCRIPTION
The `SO_LINGER` option, set with zero timeout, causes abrupt termination of TCP connections. See issue #631.

The `SO_LINGER `option was added in an attempt to solve a problem with mutex contention due to blocking behavior of `connect()` (see #35).

The enabling of this option was added in b6eb51c. Later commit 06e1ac3 changed the linger timeout to zero, introducing the issue with abrupt TCP connections termination.

Then, commit 60d8926 switched to the non-blocking socket behavior. It alone mitigated the original problem described in the issue #35. The `SO_LINGER` option, however, remained in the code. Currently, not only does it fail to serve any purpose, but it also causes abrupt termination of all TCP connections.