### PR TITLE
feat(ab_server): embeddable in-process server for same-process client…

### DIFF
--- a/src/tools/ab_server/eip.c
+++ b/src/tools/ab_server/eip.c
@@ -45,6 +45,7 @@
 #define EIP_UNREGISTER_SESSION ((uint16_t)0x0066)
 #define EIP_UNCONNECTED_SEND ((uint16_t)0x006F)
 #define EIP_CONNECTED_SEND ((uint16_t)0x0070)
+#define EIP_LIST_IDENTITY ((uint16_t)0x0063)
 
 /* supported EIP version */
 #define EIP_VERSION ((uint16_t)1)
@@ -62,6 +63,7 @@ typedef struct {
 
 static slice_s register_session(slice_s input, slice_s output, plc_s *plc, eip_header_s *header);
 static slice_s unregister_session(slice_s input, slice_s output, plc_s *plc, eip_header_s *header);
+static slice_s list_identity(slice_s output, plc_s *plc, eip_header_s *header);
 
 
 slice_s eip_dispatch_request(slice_s input, slice_s raw_output, plc_s *plc) {
@@ -116,6 +118,8 @@ slice_s eip_dispatch_request(slice_s input, slice_s raw_output, plc_s *plc) {
                                             slice_from_slice(output, EIP_HEADER_SIZE, slice_len(output) - EIP_HEADER_SIZE), plc);
             break;
 
+        case EIP_LIST_IDENTITY: response = list_identity(response, plc, &header); break;
+
         default: response = slice_make_err(ERR_TCP_UNSUPPORTED); break;
     }
 
@@ -146,6 +150,52 @@ slice_s eip_dispatch_request(slice_s input, slice_s raw_output, plc_s *plc) {
 
         return slice_from_slice(output, 0, EIP_HEADER_SIZE);
     }
+}
+
+
+slice_s list_identity(slice_s output, plc_s *plc, eip_header_s *header) {
+    (void)plc;
+    (void)header;
+
+    /* Hardcoded CIP Identity object for the emulator, so an EtherNet/IP ListIdentity (0x63)
+     * query returns a fixed, generic controller identity (vendor / device type / product
+     * code / revision / serial / product name). Vendor id is 0 (unspecified): this is an
+     * open emulator and must not present itself as a real vendor's device. */
+    static const char product_name[] = "libplctag ab_server";
+    const uint8_t name_len = (uint8_t)(sizeof(product_name) - 1);
+
+    size_t off = 0;
+
+    /* CPF item count */
+    slice_set_uint16_le(output, off, (uint16_t)1); off += 2;
+
+    /* item type (CIP Identity) + length placeholder (back-filled below) */
+    slice_set_uint16_le(output, off, (uint16_t)0x000C); off += 2;
+    const size_t len_off = off; off += 2;
+    const size_t data_start = off;
+
+    slice_set_uint16_le(output, off, (uint16_t)1); off += 2; /* encap protocol version */
+
+    /* socket address (16 bytes) - clients ignore it for ListIdentity */
+    for(size_t i = 0; i < 16; i++) { slice_set_uint8(output, off + i, (uint8_t)0); }
+    off += 16;
+
+    slice_set_uint16_le(output, off, (uint16_t)0);      off += 2; /* vendor id: 0 = unspecified (open emulator, not a real vendor device) */
+    slice_set_uint16_le(output, off, (uint16_t)0x000E); off += 2; /* device type: Programmable Logic Controller */
+    slice_set_uint16_le(output, off, (uint16_t)0x0059); off += 2; /* product code */
+    slice_set_uint8(output, off, (uint8_t)32); off += 1;          /* revision major */
+    slice_set_uint8(output, off, (uint8_t)11); off += 1;          /* revision minor */
+    slice_set_uint16_le(output, off, (uint16_t)0x0030); off += 2; /* status word */
+    slice_set_uint32_le(output, off, (uint32_t)0x00D5F123); off += 4; /* serial number */
+    slice_set_uint8(output, off, name_len); off += 1;             /* product name length */
+    for(uint8_t i = 0; i < name_len; i++) { slice_set_uint8(output, off + (size_t)i, (uint8_t)product_name[i]); }
+    off += name_len;
+    slice_set_uint8(output, off, (uint8_t)0x03); off += 1;        /* state: operational */
+
+    /* back-fill the CPF item length */
+    slice_set_uint16_le(output, len_off, (uint16_t)(off - data_start));
+
+    return slice_from_slice(output, 0, off);
 }
 
 

--- a/src/tools/ab_server/main.c
+++ b/src/tools/ab_server/main.c
@@ -637,11 +637,6 @@ void parse_cip_tag(const char *tag_str, plc_s *plc) {
     /* create the tag data mutex */
     if(mutex_create(&(tag->data_mutex)) != MUTEX_STATUS_OK) { log_error("Unable to create tag data mutex!"); }
 
-
-    /* create the tag data mutex */
-    if(mutex_create(&(tag->data_mutex)) != MUTEX_STATUS_OK) { log_error("Unable to create tag data mutex!"); }
-
-
     /* try to match the three parts of a tag definition string. */
 
     /* first match the name. */

--- a/src/tools/ab_server/main.c
+++ b/src/tools/ab_server/main.c
@@ -39,6 +39,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <time.h>
+#include <stdatomic.h>
 
 #if defined(IS_WINDOWS)
 #    include <windows.h>
@@ -65,11 +66,11 @@ static void parse_cip_tag(const char *tag, plc_s *plc);
 static slice_s request_handler(slice_s input, slice_s output, void *plc);
 
 
+/* shutdown flag; set by the signal/console handler or ab_server_stop(), polled by tcp_server_start() */
+atomic_int done = 0;
+
+
 #ifdef IS_WINDOWS
-
-typedef volatile int sig_flag_t;
-
-sig_flag_t done = 0;
 
 /* straight from MS' web site :-) */
 int WINAPI CtrlHandler(DWORD fdwCtrlType) {
@@ -77,29 +78,29 @@ int WINAPI CtrlHandler(DWORD fdwCtrlType) {
             // Handle the CTRL-C signal.
         case CTRL_C_EVENT:
             log_info("^C event");
-            done = 1;
+            atomic_store(&done, 1);
             return TRUE;
 
             // CTRL-CLOSE: confirm that the user wants to exit.
         case CTRL_CLOSE_EVENT:
             log_info("Close event");
-            done = 1;
+            atomic_store(&done, 1);
             return TRUE;
 
             // Pass other signals to the next handler.
         case CTRL_BREAK_EVENT:
             log_info("^Break event");
-            done = 1;
+            atomic_store(&done, 1);
             return TRUE;
 
         case CTRL_LOGOFF_EVENT:
             log_info("Logoff event");
-            done = 1;
+            atomic_store(&done, 1);
             return TRUE;
 
         case CTRL_SHUTDOWN_EVENT:
             log_info("Shutdown event");
-            done = 1;
+            atomic_store(&done, 1);
             return TRUE;
 
         default: log_info("Default Event: %d", fdwCtrlType); return FALSE;
@@ -116,14 +117,10 @@ void setup_break_handler(void) {
 
 #else
 
-typedef volatile sig_atomic_t sig_flag_t;
-
-sig_flag_t done = 0;
-
 void SIGINT_handler(int not_used) {
     (void)not_used;
 
-    done = 1;
+    atomic_store(&done, 1);
 }
 
 void setup_break_handler(void) {
@@ -134,12 +131,38 @@ void setup_break_handler(void) {
     memset(&act, 0, sizeof(act));
     act.sa_handler = SIGINT_handler;
     sigaction(SIGINT, &act, NULL);
+    sigaction(SIGTERM, &act, NULL);
+#ifdef SIGQUIT
+    sigaction(SIGQUIT, &act, NULL);
+#endif
 }
 
 #endif
 
 
-int main(int argc, const char **argv) {
+static void cleanup_tags(plc_s *plc);
+
+#ifdef AB_SERVER_LIB
+/* libab_server ships its own copies of utility functions (socket_*, mem_*, mutex_*,
+ * thread_*, ...) whose names also exist in libplctag. When both are loaded into one
+ * process (the same-process client+server case), the lib is built with hidden symbol
+ * visibility and exports only these two entry points, so neither lib's internal calls
+ * can be interposed by the other's. */
+#  if defined(__GNUC__) && !defined(_WIN32)
+#    define AB_SERVER_API __attribute__((visibility("default")))
+#  else
+#    define AB_SERVER_API
+#  endif
+
+/* In-process embedding entry points (see apps/demo/ABPLC). ab_server_stop() is callable
+ * from another thread to ask the blocking ab_server_main() loop to return. */
+AB_SERVER_API void ab_server_stop(void) { atomic_store(&done, 1); }
+
+AB_SERVER_API int ab_server_main(int argc, const char **argv)
+#else
+int main(int argc, const char **argv)
+#endif
+{
     tcp_server_p server = NULL;
     plc_s plc;
 
@@ -167,7 +190,25 @@ int main(int argc, const char **argv) {
 
     tcp_server_destroy(server);
 
+    /* Free the tag list. Harmless for the standalone exe (the OS reclaims it), but
+     * required for the embedded library so repeated start/stop cycles do not leak. */
+    cleanup_tags(&plc);
+
     return 0;
+}
+
+
+static void cleanup_tags(plc_s *plc) {
+    tag_def_s *tag = plc->tags;
+    while(tag) {
+        tag_def_s *next = tag->next_tag;
+        if(tag->name) { free(tag->name); }
+        if(tag->data) { free(tag->data); }
+        if(tag->data_mutex) { mutex_destroy(&(tag->data_mutex)); }
+        free(tag);
+        tag = next;
+    }
+    plc->tags = NULL;
 }
 
 

--- a/src/tools/ab_server/tcp_server.c
+++ b/src/tools/ab_server/tcp_server.c
@@ -262,6 +262,7 @@ THREAD_FUNC(conn_handler) {
 
     /* see tcp_server_start() where these are malloc'ed for us */
     free(session->server_context);
+    thread_destroy(&(session->thread)); /* detached thread: free its handle (no join) */
     free(session);
 
     atomic_fetch_sub(&server->active_handlers, 1);

--- a/src/tools/ab_server/tcp_server.c
+++ b/src/tools/ab_server/tcp_server.c
@@ -40,6 +40,7 @@
 #include "utils.h"
 #include "log.h"
 #include <limits.h>
+#include <stdatomic.h>
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
@@ -54,13 +55,14 @@ struct tcp_server {
     slice_s (*handler)(slice_s input, slice_s output, void *context);
     void *context;
     size_t context_size;
+    atomic_int active_handlers; /* count of running conn_handler threads, for drain-on-shutdown */
+    atomic_bool done;           /* shutdown flag; any thread may raise it, all monitor it */
 };
 
 struct client_session {
     SOCKET client_fd;
     tcp_server_p server;
     void *server_context;
-    bool *server_done;
     slice_s buffer;
     thread_p thread;
 };
@@ -86,15 +88,14 @@ tcp_server_p tcp_server_create(const char *host, const char *port,
         server->handler = handler;
         server->context = context;
         server->context_size = context_size;
+        atomic_store(&server->active_handlers, 0);
+        atomic_store(&server->done, false);
     }
 
     return server;
 }
 
-void tcp_server_start(tcp_server_p server, volatile sig_atomic_t *terminate) {
-    static bool done; /* static so it doesn't go out of scope, since it's passed to sub-threads. */
-    done = false;     /* initialised every invocation for logic sake, even though that's once. */
-
+void tcp_server_start(tcp_server_p server, atomic_int *terminate) {
     log_info("Waiting for new client connection.");
 
     do {
@@ -123,7 +124,6 @@ void tcp_server_start(tcp_server_p server, volatile sig_atomic_t *terminate) {
             memcpy(session->server_context, server->context, server->context_size);
             session->client_fd = client_fd; /* copy of a temporary value - no thread safety concerns */
             session->server = server;       /* reference to a long-lived struct, which has values and the original context */
-            session->server_done = &done;   /* reference to a flag that any thread can raise (and all must monitor) */
 
             if(thread_create(&(session->thread), conn_handler, 10 * 1024, session) != THREAD_STATUS_OK) {
                 log_error("ERROR: Unable to create connection handler thread!");
@@ -133,15 +133,20 @@ void tcp_server_start(tcp_server_p server, volatile sig_atomic_t *terminate) {
             continue;
         } else {
             log_error("ERROR: Received error, %s, accepting new client connection!", err_to_string(accept_status));
-            done = true;
+            atomic_store(&server->done, true);
         }
 
         /* give back the CPU. */
         system_yield();
-    } while(!done && !*terminate);
+    } while(!atomic_load(&server->done) && !atomic_load(terminate));
 
     /* in case we were terminated by signal, raise the done flag for all the threads to exit */
-    done = true;
+    atomic_store(&server->done, true);
+
+    /* Wait for all in-flight connection handlers to finish before returning, so the caller
+     * (e.g. the embedded ab_server_main) can safely free the PLC tags/mutexes without a
+     * handler thread still touching them. */
+    while(atomic_load(&server->active_handlers) > 0) { system_yield(); }
 }
 
 
@@ -172,6 +177,9 @@ THREAD_FUNC(conn_handler) {
 
     /* no one will join this thread, so clean ourselves up. */
     thread_detach();
+
+    /* register with the server so tcp_server_start() can drain us on shutdown. */
+    atomic_fetch_add(&server->active_handlers, 1);
 
     accumulated_data = slice_make(input_buf, 0);            /* start with zero accumulated data */
     read_target = slice_make(input_buf, sizeof(input_buf)); /* read into entire buffer initially */
@@ -248,13 +256,15 @@ THREAD_FUNC(conn_handler) {
             }
         }
     } while((rc == ERR_TCP_INCOMPLETE || rc == ERR_TCP_PROCESSED)
-            && (*(session->server_done) != true)); /* make sure another thread hasn't killed the server */
+            && !atomic_load(&server->done)); /* make sure another thread hasn't killed the server */
 
     socket_close(session->client_fd);
 
     /* see tcp_server_start() where these are malloc'ed for us */
     free(session->server_context);
     free(session);
+
+    atomic_fetch_sub(&server->active_handlers, 1);
 
     THREAD_RETURN(0);
 }

--- a/src/tools/ab_server/tcp_server.h
+++ b/src/tools/ab_server/tcp_server.h
@@ -33,7 +33,7 @@
 
 #pragma once
 
-#include <signal.h>
+#include <stdatomic.h>
 #include <stdbool.h>
 #include "slice.h"
 
@@ -50,5 +50,5 @@ typedef struct tcp_server *tcp_server_p;
 extern tcp_server_p tcp_server_create(const char *host, const char *port,
                                       slice_s (*handler)(slice_s input, slice_s output, void *context), void *context,
                                       size_t context_size);
-extern void tcp_server_start(tcp_server_p server, volatile sig_atomic_t *terminate);
+extern void tcp_server_start(tcp_server_p server, atomic_int *terminate);
 extern void tcp_server_destroy(tcp_server_p server);


### PR DESCRIPTION
…+server #509

- add ab_server_main()/ab_server_stop() (under AB_SERVER_LIB) so a host can run the simulator on a thread and stop it; export only these two entry points (hidden visibility) so ab_server and libplctag do not interpose each other's identically-named utility symbols when loaded in one process
- add EtherNet/IP ListIdentity (0x63) responder with a neutral, unspecified-vendor identity
- fix multi-instance shutdown: the shutdown flag was a function-local static, so concurrent in-process servers shared one object (data race + cross-instance shutdown); move it into struct tcp_server as a per-instance atomic_bool
- make the terminate flag atomic_int (set cross-thread by ab_server_stop, not just a signal) and drain in-flight connection handlers before tcp_server_start returns
- free the tag list on exit; handle SIGTERM/SIGQUIT