### PR TITLE
Fix numeric segment overflow

### DIFF
--- a/src/libplctag/protocols/omron/conn.c
+++ b/src/libplctag/protocols/omron/conn.c
@@ -2882,8 +2882,9 @@ int receive_forward_open_response(omron_conn_p conn) {
             } else {
                 rc = PLCTAG_ERR_REMOTE_ERR;
 
+                /* comparing pointers directly is UB, so compare the integer values instead. */
                 if(fo_resp->general_status == 0x01 && fo_resp->status_size >= 2
-                   && (&fo_resp->status_size + 5) <= (conn->data + conn->data_size)) {
+                   && (intptr_t)(&fo_resp->status_size + 5) <= (intptr_t)(conn->data + conn->data_size)) {
                     /* we might have an error that tells us the actual size to use. */
                     uint8_t *data = &fo_resp->status_size;
                     int extended_status = data[1] | (data[2] << 8);

--- a/src/tools/ab_server/cip.c
+++ b/src/tools/ab_server/cip.c
@@ -1188,6 +1188,16 @@ bool parse_tag_path(slice_s tag_path, plc_s *plc, tag_def_s **tag, uint32_t *num
     while(offset < slice_len(tag_path)) {
         uint8_t segment_type = slice_get_uint8(tag_path, offset);
 
+        /*
+         * The caller's indexes[] array holds exactly max_indexes entries, so this must be checked
+         * before the writes below and not after the increment: a remote client controls how many
+         * numeric segments the path carries.
+         */
+        if(*num_indexes >= max_indexes) {
+            log_info("More numeric segments than the expected maximum, %u!", max_indexes);
+            return false;
+        }
+
         switch(segment_type) {
             case 0x28:        // Single byte value
                 offset += 1;  // skip segment type
@@ -1217,11 +1227,6 @@ bool parse_tag_path(slice_s tag_path, plc_s *plc, tag_def_s **tag, uint32_t *num
         }
 
         (*num_indexes)++;
-
-        if(*num_indexes > max_indexes) {
-            log_info("More numeric segments, %zu, than expected, %zu!", *num_indexes, max_indexes);
-            return false;
-        }
     }
 
     /* the only valid number of indexes is zero or the number of dimensions in the tag. */

--- a/src/tools/ab_server/main.c
+++ b/src/tools/ab_server/main.c
@@ -604,7 +604,8 @@ void parse_pccc_tag(const char *tag_str, plc_s *plc) {
         usage();
     } else {
         /* copy the string. */
-        for(size_t i = 0; i < len && i < (size_t)200; i++) { data_file_name[i] = tag_str[start + i]; }
+        /* leave room for the terminating nul, str_cmp_i() below needs the string terminated. */
+        for(size_t i = 0; i < len && i < sizeof(data_file_name) - 1; i++) { data_file_name[i] = tag_str[start + i]; }
 
         /* check data file for a match. */
         if(str_cmp_i(data_file_name, "B3") == 0) {
@@ -659,7 +660,8 @@ void parse_pccc_tag(const char *tag_str, plc_s *plc) {
         usage();
     } else {
         /* copy the string. */
-        for(size_t i = 0; i < len && i < (size_t)200; i++) { size_str[i] = tag_str[start + i]; }
+        /* leave room for the terminating nul, str_cmp_i() below needs the string terminated. */
+        for(size_t i = 0; i < len && i < sizeof(size_str) - 1; i++) { size_str[i] = tag_str[start + i]; }
 
         start += len;
     }
@@ -772,7 +774,8 @@ void parse_cip_tag(const char *tag_str, plc_s *plc) {
         usage();
     } else {
         /* copy the string. */
-        for(size_t i = 0; i < len && i < (size_t)200; i++) { tag_name[i] = tag_str[start + i]; }
+        /* leave room for the terminating nul, str_cmp_i() below needs the string terminated. */
+        for(size_t i = 0; i < len && i < sizeof(tag_name) - 1; i++) { tag_name[i] = tag_str[start + i]; }
 
         start += len;
     }
@@ -793,7 +796,8 @@ void parse_cip_tag(const char *tag_str, plc_s *plc) {
         usage();
     } else {
         /* copy the string. */
-        for(size_t i = 0; i < len && i < (size_t)200; i++) { type_str[i] = tag_str[start + i]; }
+        /* leave room for the terminating nul, str_cmp_i() below needs the string terminated. */
+        for(size_t i = 0; i < len && i < sizeof(type_str) - 1; i++) { type_str[i] = tag_str[start + i]; }
 
         start += len;
     }
@@ -815,7 +819,8 @@ void parse_cip_tag(const char *tag_str, plc_s *plc) {
         usage();
     } else {
         /* copy the string. */
-        for(size_t i = 0; i < len && i < (size_t)200; i++) { dim_str[i] = tag_str[start + i]; }
+        /* leave room for the terminating nul, str_cmp_i() below needs the string terminated. */
+        for(size_t i = 0; i < len && i < sizeof(dim_str) - 1; i++) { dim_str[i] = tag_str[start + i]; }
 
         start += len;
     }


### PR DESCRIPTION
Fix: 
- UB in address comparison
- overflow if malicious client sends more than three numeric segments.
- ensure sufficient spacer for nul terminator byte.